### PR TITLE
Create build script for FreeAPS X (FAX)

### DIFF
--- a/BuildFAX.sh
+++ b/BuildFAX.sh
@@ -93,6 +93,8 @@ then
     clear
     echo -e "\n\n Downloading FAX to your Downloads folder.\n--------------------------------\n"
     git clone --branch=$BRANCH --recurse-submodules $REPO
+    cd freeaps
+    curl -O https://raw.githubusercontent.com/bjornoleh/loopbuildscripts/buildFAX/FAXfiles/ConfigOverride.xcconfig
 
     echo -e "--------------------------------\n\n🛑 Please check for errors listed above before proceeding. If there are no errors listed, code has successfully downloaded.\n"
     echo -e "Type 1 and hit enter to open Xcode. You may close the terminal after Xcode opens\n\n"
@@ -102,7 +104,6 @@ then
     do
         case $opt in
             "Continue")
-                cd freeaps
                 xed ./FreeAPS.xcworkspace
                 open https://www.loopandlearn.org/freeaps-x/#build
                 exit 0

--- a/BuildFAX.sh
+++ b/BuildFAX.sh
@@ -1,0 +1,164 @@
+# !/bin/bash
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+PURPLE='\033[0;35m'
+BOLD='\033[1m'
+NC='\033[0m'
+WHICH=FAX
+FAX_BUILD=$(date +'%y%m%d-%H%M')
+FAX_DIR=~/Downloads/BuildFAX/
+SCRIPT_DIR=~/Downloads/BuildFAX/Scripts
+
+
+mkdir $FAX_DIR
+mkdir $SCRIPT_DIR
+
+clear
+
+echo -e "${RED}\n\n--------------------------------\n\nImportant\n\nPlease understand that this project:\n-Is highly experimental\n-Is not approved for therapy\n-You take full responsibility for building and running this system and do so at your own risk.\n\nYou may only proceed if you agree..\n\n--------------------------------\n\n${NC}"
+echo -e "Type the number from below and hit enter to proceed."
+options=("Agree" "Disagree")
+select opt in "${options[@]}"
+do
+    case $opt in
+        "Agree")
+            break
+            ;;
+        "Disagree")
+            echo -e "\n${RED}Did not agree to terms of use.${NC}\n\n";
+            exit 0
+            break
+            ;;
+        *)
+    esac
+done
+
+clear
+
+echo -e "\n\n--------------------------------\n\nWelcome to Loop and Learn Scripts.\n\n This script will assist you in preparing your computer as well as downloading and building FreeAPS X (FAX), the iPhone implementation of OpenAPS (oref0 / oref1). Before you begin, please ensure that you have Xcode installed and your phone is plugged into your computer\n\n--------------------------------\n\n"
+echo -e "Type the number from below and hit enter to proceed."
+options=("Build FAX" "Utility Scripts" "Cancel")
+select opt in "${options[@]}"
+do
+    case $opt in
+        "Build FAX")
+            WHICH=FAX
+            break
+            ;;
+        "Utility Scripts")
+            WHICH=UtilityScripts
+            break
+            ;;
+        "Cancel")
+            clear
+            echo -e "\n${RED}User cancelled!${NC}\n\n⬆️  You can press the up arrow on the keyboard followed by the Enter key to start the script from the beginning.\n\n";
+            exit 0
+            break
+            ;;
+        *)
+    esac
+done
+
+clear
+
+if [ "$WHICH" = "FAX" ]
+then
+
+    echo -e "Please select which version of FAX you would like to download and build.\n\nType the number for the branch and hit enter to select the branch.\nType 4 and hit enter to cancel.\n\n"
+    options=("Master Branch" "Cancel")
+    select opt in "${options[@]}"
+    do
+        case $opt in
+            "Master Branch")
+                FOLDERNAME=FAX-Master
+                REPO=https://github.com/ivalkou/freeaps
+                BRANCH=master
+                break
+                ;;
+            "Cancel")
+                clear
+                echo -e "\n${RED}User cancelled!${NC}\n\n⬆️  You can press the up arrow on the keyboard followed by the Enter key to start the script from the beginning.\n\n";
+                exit 0
+                break
+                ;;
+            *)
+        esac
+    done
+
+    clear
+    FAX_DIR=~/Downloads/BuildFAX/$FOLDERNAME-$FAX_BUILD
+    mkdir $FAX_DIR
+    cd $FAX_DIR
+    pwd
+    clear
+    echo -e "\n\n Downloading FAX to your Downloads folder.\n--------------------------------\n"
+    git clone --branch=$BRANCH --recurse-submodules $REPO
+
+    echo -e "--------------------------------\n\n🛑 Please check for errors listed above before proceeding. If there are no errors listed, code has successfully downloaded.\n"
+    echo -e "Type 1 and hit enter to open Xcode. You may close the terminal after Xcode opens\n\n"
+
+    options=("Continue" "Cancel")
+    select opt in "${options[@]}"
+    do
+        case $opt in
+            "Continue")
+                cd freeaps
+                xed ./FreeAPS.xcworkspace
+                open https://www.loopandlearn.org/freeaps-x/#build
+                exit 0
+                break
+                ;;
+            "Cancel")
+            clear
+                echo -e "\n${RED}User cancelled!${NC}\n\n⬆️  You can press the up arrow on the keyboard followed by the Enter key to start the script from the beginning.\n\n";
+                exit 0
+                break
+                ;;
+            *)
+        esac
+    done
+
+else
+    cd $FAX_DIR/Scripts
+    clear
+    echo -e "\n\n--------------------------------\n\nThese scripts will automate several cleanup options for you.\n\n--------------------------------\n\n➡️  Clean Carthage and Derived Data:\nThis script is used to clean up data from old builds from Xcode. Xcode should be closed when running this script.\n\n➡️  Xcode Cleanup (The Big One):\nThis script is used to clean up “stuff” from Xcode. It is typically used after uninstalling Xcode and before installing a new version of Xcode. It can free up a substantial amount of space. Sometimes you might be directed to use this script to resolve a problem, ‼️  beware that you might be required to fully uninstall and reinstall Xcode after running this script.‼️  Usually, Xcode will recover the simulator and other files it needs without needing to be reinstalled.\n\n"
+    echo -e "Type the number from below and hit enter to proceed."
+    options=("Clean Derived Data" "Xcode Cleanup (The Big One)" "Clean Profiles and Derived Data" "Cancel")
+    select opt in "${options[@]}"
+    do
+        case $opt in
+            "Clean Derived Data")
+                echo -e "\n\n--------------------------------\n\nDownloading Derived Data Script\n\n--------------------------------\n\n"
+                rm ./CleanCartDerived.sh
+                curl -fsSLo ./CleanCartDerived.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/CleanCartDerived.sh
+                clear
+                source ./CleanCartDerived.sh
+                break
+                ;;
+            "Xcode Cleanup (The Big One)")
+                echo -e "\n\n--------------------------------\n\nDownloading Xcode Cleanup Script\n\n--------------------------------\n\n"
+                rm ./XcodeClean.sh
+                curl -fsSLo ./XcodeClean.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/XcodeClean.sh
+                clear
+                source ./XcodeClean.sh
+                break
+                ;;
+            "Clean Profiles and Derived Data")
+                echo -e "\n\n--------------------------------\n\nDownloading Profiles and Derived Data Script\n\n--------------------------------\n\n"
+                rm ./CleanProfCartDerived.sh
+                curl -fsSLo ./CleanProfCartDerived.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/CleanProfCartDerived.sh
+                clear
+                source ./CleanProfCartDerived.sh
+                break
+                ;;
+            "Cancel")
+                clear
+                echo -e "\n${RED}User cancelled!${NC}\n\n⬆️  You can press the up arrow on the keyboard followed by the Enter key to start the script from the beginning.\n\n";
+                exit 0
+                break
+                ;;
+            *)
+        esac
+    done
+fi
+

--- a/BuildFAX.sh
+++ b/BuildFAX.sh
@@ -65,7 +65,7 @@ if [ "$WHICH" = "FAX" ]
 then
 
     echo -e "Please select which version of FAX you would like to download and build.\n\nType the number for the branch and hit enter to select the branch.\nType 4 and hit enter to cancel.\n\n"
-    options=("Master Branch" "Cancel")
+    options=("Master Branch" "Dev Branch" "Cancel")
     select opt in "${options[@]}"
     do
         case $opt in
@@ -73,6 +73,12 @@ then
                 FOLDERNAME=FAX-Master
                 REPO=https://github.com/ivalkou/freeaps
                 BRANCH=master
+                break
+                ;;
+                "Dev Branch")
+                FOLDERNAME=FAX-dev
+                REPO=https://github.com/ivalkou/freeaps
+                BRANCH=dev
                 break
                 ;;
             "Cancel")

--- a/BuildFAX.sh
+++ b/BuildFAX.sh
@@ -98,7 +98,7 @@ then
     pwd
     clear
     echo -e "\n\n Downloading FAX to your Downloads folder.\n--------------------------------\n"
-    git clone --branch=$BRANCH --recurse-submodules $REPO
+    git clone --branch=$BRANCH $REPO
     cd freeaps
     curl -O https://raw.githubusercontent.com/loopnlearn/loopbuildscripts/buildFAX/FAXfiles/ConfigOverride.xcconfig
 

--- a/BuildFAX.sh
+++ b/BuildFAX.sh
@@ -100,7 +100,7 @@ then
     echo -e "\n\n Downloading FAX to your Downloads folder.\n--------------------------------\n"
     git clone --branch=$BRANCH --recurse-submodules $REPO
     cd freeaps
-    curl -O https://raw.githubusercontent.com/bjornoleh/loopbuildscripts/buildFAX/FAXfiles/ConfigOverride.xcconfig
+    curl -O https://raw.githubusercontent.com/loopnlearn/loopbuildscripts/buildFAX/FAXfiles/ConfigOverride.xcconfig
 
     echo -e "--------------------------------\n\n🛑 Please check for errors listed above before proceeding. If there are no errors listed, code has successfully downloaded.\n"
     echo -e "Type 1 and hit enter to open Xcode. You may close the terminal after Xcode opens\n\n"

--- a/FAXfiles/ConfigOverride.xcconfig
+++ b/FAXfiles/ConfigOverride.xcconfig
@@ -1,0 +1,3 @@
+// Please find your developer team ID in https://developer.apple.com/account/resources/certificates/list (top right corner)
+// Enter your developer team ID below (replace XXXXXXXXXX with your developer team ID). The build targets will now be signed automatically.
+DEVELOPER_TEAM = XXXXXXXXXX

--- a/FAXfiles/ConfigOverride.xcconfig
+++ b/FAXfiles/ConfigOverride.xcconfig
@@ -1,3 +1,8 @@
-// Please find your developer team ID in https://developer.apple.com/account/resources/certificates/list (top right corner)
-// Enter your developer team ID below (replace XXXXXXXXXX with your developer team ID). The build targets will now be signed automatically.
-DEVELOPER_TEAM = XXXXXXXXXX
+//// --- OPTIONAL FEATURE: ---
+//// Automatically sign targets using this ConfigOverride file
+//// Please find your developer team ID by following this link:
+//// https://developer.apple.com/account/resources/certificates/list
+//// Enter your developer team ID below (replace XXXXXXXX). 
+//// The build targets will now be signed automatically.
+//// Remove the leading "//" from the line below to enable use of this file:
+// DEVELOPER_TEAM = XXXXXXXX


### PR DESCRIPTION
This is a modified build script based on BuildLoop.sh, which allows the master or dev branch of FreeAPS X (FAX) to be cloned into /Downloads/BuildFAX. The Utility scripts are unchanged. The script opens https://www.loopandlearn.org/freeaps-x/#build when opening Xcode. That page will need to be revised soon, by the way. 

If this PR is merged with loopnlearn:main, the script can be run by pasting this into Terminal:
`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/BuildFAX.sh)"`

To test before merging, use this command instead:
`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/bjornoleh/LoopBuildScripts/buildFAX/BuildFAX.sh)"`

The script also downloads ConfigOverride.xcconfig, which allows for all targets to be automatically signed. This signing will persist if a different branch is checked out in the same directory, since it is in .gitignore of FAX. 

Contents of ConfigOverride.xcconfig:

//// --- OPTIONAL FEATURE: ---
//// Automatically sign targets using this ConfigOverride file
//// Please find your developer team ID by following this link:
//// https://developer.apple.com/account/resources/certificates/list
//// Enter your developer team ID below (replace XXXXXXXX). 
//// The build targets will now be signed automatically.
//// Remove the leading "//" from the line below to enable use of this file:
// DEVELOPER_TEAM = XXXXXXXX

