### PR TITLE
Prep for loop 3

### DIFF
--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -247,6 +247,7 @@ then
                         echo -e "\n If the last line has your Apple Developer ID"
                         echo -e "   with no slashes at the beginning of the line"
                         echo -e "   your targets will be automatically signed"
+                        echo -e "If ID is wrong - you can manually edit the file now\n"
                         read -p "Return when ready to continue  " dummy
                     else
                         # make sure the LoopConfigOverride.xcconfig exists in clone

--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -72,8 +72,22 @@ else
     LOOPCONFIGOVERRIDE_VALID=0
 fi
 
-mkdir $LOOP_DIR
-mkdir $SCRIPT_DIR
+if [ ! -d ${LOOP_DIR} ]
+then
+    mkdir $LOOP_DIR
+fi
+if [ ! -d ${SCRIPT_DIR} ]
+then
+    mkdir $SCRIPT_DIR
+fi
+
+# make a copy of this script in script folder
+cd ${SCRIPT_DIR}
+if [ -e ./BuildLoop.sh ]
+then
+    rm ./BuildLoop.sh
+fi
+curl -fsSLo ./BuildLoop.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/BuildLoop.sh
 
 # clear
 

--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -307,14 +307,14 @@ if [ "$WHICH" = "Loop" ]; then
                     else
                         # make sure the LoopConfigOverride.xcconfig exists in clone
                         if [ -e LoopWorkspace/LoopConfigOverride.xcconfig ]; then
-                            echo -e "Choose to enter Apple ID or wait and Sign Manually (later in Xcode)"
-                            echo -e "\nIf you choose Apple ID, script will help you find it\n"
+                            echo -e "Choose to enter Apple Developer ID or wait and Sign Manually (later in Xcode)"
+                            echo -e "\nIf you choose Apple Developer ID, script will help you find it\n"
                             choose_or_cancel
-                            options=("Enter Apple ID" "Sign Manually")
+                            options=("Enter Apple Developer ID" "Sign Manually")
                             select opt in "${options[@]}"
                             do
                                 case $opt in
-                                    "Enter Apple ID")
+                                    "Enter Apple Developer ID")
                                         create_persistent_config_override
                                         break
                                         ;;

--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -20,10 +20,11 @@ SCRIPT_DIR=~/Downloads/BuildLoop/Scripts
 FRESH_CLONE=1
 
 # BRANCH_TYPE
-BRANCH_TYPE=master
-#   Default value is master - determine branch for clone
-#   To build Loop-dev or FreeAPS-dev:
+#   This determines the branch for git clone command
+#   Default value is master
+#   To build Loop with dev or FreeAPS with freeaps_dev:
 #      use -d flag
+BRANCH_TYPE=master
 
 ############################################################
 # Process the input options                                #
@@ -48,9 +49,7 @@ while getopts 'dht' OPTION; do
       d) # set flag to download dev branches
          echo -e "  -d flag, sets BRANCH_TYPE=dev"
          BRANCH_TYPE=dev
-         echo -e ${LOOP_BUILD}
          LOOP_BUILD="dev"-${LOOP_BUILD}
-         echo -e ${LOOP_BUILD}
          sleep 1
          ;;
       \?) # Invalid option
@@ -58,22 +57,6 @@ while getopts 'dht' OPTION; do
          exit;;
    esac
 done
-# shift "$(($OPTIND -1))"
-# echo -e "There were ${OPTIND} options processed"
-
-if [ "$BRANCH_TYPE" = "dev" ]
-then
-    # To test prior to release, uncomment these 3 rows
-    BRANCH_LOOP=dev
-    BRANCH_FREE=freeaps_dev
-    LOOPCONFIGOVERRIDE_VALID=1
-    echo -e " -- BRANCH_LOOP set to  ${BRANCH_LOOP}  --"
-    echo -e " -- BRANCH_FREE set to  ${BRANCH_FREE}  --"
-else
-    BRANCH_LOOP=master
-    BRANCH_FREE=freeaps
-    LOOPCONFIGOVERRIDE_VALID=0
-fi
 
 if [ ! -d ${LOOP_DIR} ]
 then
@@ -133,8 +116,7 @@ echo -e "\n--------------------------------\n"
 echo -e "${BOLD}Welcome to the Loop and Learn\n  Build-Select Script\n${NC}"
 echo -e "This script will assist you in one of these actions:"
 echo -e "  1 Download and build Loop"
-echo -e "      You will be asked to choose from the"
-echo -e "      released versions of Loop or FreeAPS"
+echo -e "      You will be asked to choose from Loop or FreeAPS"
 echo -e "  2 Download and build LoopFollow"
 echo -e "  3 Prepare your computer using a Utility Script"
 echo -e "     when updating your computer or an app"
@@ -177,6 +159,19 @@ then
     echo -e "  your phone is plugged into your computer\n"
     echo -e "Please select which version of Loop you would like to download and build.\n"
     echo -e "Type a number from the list below and return"
+    if [ "$BRANCH_TYPE" = "dev" ]
+    then
+        BRANCH_LOOP=dev
+        BRANCH_FREE=freeaps_dev
+        LOOPCONFIGOVERRIDE_VALID=1
+        echo -e "\n ${RED}${BOLD}You are running the script with a -d flag${NC}\n"
+        echo -e " -- If you choose Loop,    branch is ${RED}${BOLD}${BRANCH_LOOP}${NC}"
+        echo -e " -- If you choose FreeAPS, branch is ${RED}${BOLD}${BRANCH_FREE}${NC}\n"
+    else
+        BRANCH_LOOP=master
+        BRANCH_FREE=freeaps
+        LOOPCONFIGOVERRIDE_VALID=0
+    fi
     echo -e "${RED}${BOLD}  Any other entry cancels\n${NC}"
     options=("Loop" "FreeAPS")
     select opt in "${options[@]}"
@@ -226,7 +221,7 @@ then
     echo -e "   If there are no errors listed, code has successfully downloaded.\n"
     echo -e "Type 1 and return to continue if and ONLY if"
     echo -e "  there are no errors (scroll up in terminal window to look for the word error)"
-    echo -e "\nAfter you Type 1 and return:"
+    echo -e "\nAfter you type 1 and return:"
     echo -e "* The Loop and Learn webpage with abbreviated build steps will be displayed in your browser"
     echo -e "* The LoopDocs webpage with detailed build steps will be displayed in your browser"
     echo -e "* Xcode will open with your current download (wait for it)\n"
@@ -252,7 +247,7 @@ then
                         echo -e "\n If the last line has your Apple Developer ID"
                         echo -e "   with no slashes at the beginning of the line"
                         echo -e "   your targets will be automatically signed"
-                        read -p "Hit return when ready to continue  " dummy
+                        read -p "Return when ready to continue  " dummy
                     else
                         # make sure the LoopConfigOverride.xcconfig exists in clone
                         if [ -e LoopWorkspace/LoopConfigOverride.xcconfig ]
@@ -267,7 +262,7 @@ then
                                         echo -e "Log in to the page and note your 10-character Team ID"
                                         echo -e "Then, return to terminal window"
                                         open "https://developer.apple.com/account/#!/membership"
-                                        read -p "Enter the ID and hit return: " devID
+                                        read -p "Enter the ID and return: " devID
                                         if [ ${#devID} -ne 10 ]
                                         then
                                             echo -e "Something was wrong with entry"

--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -120,11 +120,12 @@ function configure_folders_download_script() {
         mkdir $SCRIPT_DIR
     fi
 
-    # store a fresh copy of this script in script directory
-    if [ -e ${SCRIPT_DIR}/BuildLoop.sh ]; then
-        rm ${SCRIPT_DIR}/BuildLoop.sh
-    fi
+    # store a copy of this script in script directory
     curl -fsSLo ${SCRIPT_DIR}/BuildLoop.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/BuildLoop.sh
+}
+
+function return_when_ready() {
+    read -p "Return when ready to continue  " dummy
 }
 
 function report_persistent_config_override() {
@@ -137,7 +138,7 @@ function report_persistent_config_override() {
     echo -e "   your targets will be automatically signed"
     echo -e "Any line that starts with // is ignored"
     echo -e "If ID is wrong - you should manually edit the file or delete the file now\n"
-    read -p "Return when ready to continue  " dummy
+    return_when_ready
 }
 
 function create_persistent_config_override() {
@@ -145,10 +146,12 @@ function create_persistent_config_override() {
     echo -e "* Log in to the page and note your 10-character Team ID"
     echo -e " * If the Memebship page does not show, you may need to select it"
     echo -e " * If you already have your account open in your browser, you may need to go to the already opened page"
-    echo -e " * For reference, this is the page that will open:"
+    echo -e " * Once you get your ID, return to terminal window"
+    echo -e "This is the page that will open:"
     echo -e "   https://developer.apple.com/account/#!/membership\n"
-    echo -e "Then, return to terminal window"
+    return_when_ready
     open "https://developer.apple.com/account/#!/membership"
+    echo -e " * Click in terminal window\n"
     read -p "Enter the ID and return: " devID
     if [ ${#devID} -ne 10 ]; then
         echo -e "Something was wrong with entry"
@@ -328,23 +331,22 @@ if [ "$WHICH" = "Loop" ]; then
                     fi
                     echo -e "\n--------------------------------\n"
                 fi
+                echo -e "The following items will open (in a few seconds)"
+                echo -e "* The Loop and Learn webpage with abbreviated build steps will be displayed in your browser"
+                echo -e "* The LoopDocs webpage with detailed build steps will be displayed in your browser"
+                echo -e "* Xcode will open with your current download (wait for it)\n"
                 # the helper page displayed depends on validity of persistent override
                 if [ ${LOOPCONFIGOVERRIDE_VALID} == 1 ]; then
                     # change this page to the one (not yet written) for persistent override
-                    echo -e "* The Loop and Learn webpage with abbreviated build steps will be displayed in your browser"
-                    sleep 2
+                    sleep 3
                     open https://www.loopandlearn.org/workspace-build-loop
                 else
-                    echo -e "* The Loop and Learn webpage with abbreviated build steps will be displayed in your browser"
-                    sleep 2
+                    sleep 3
                     open https://www.loopandlearn.org/workspace-build-loop
                 fi
-                echo -e "* The LoopDocs webpage with detailed build steps will be displayed in your browser"
-                sleep 2
+                sleep 3
                 open "https://loopkit.github.io/loopdocs/build/step14/#prepare-to-build"
                 cd LoopWorkspace
-                sleep 2
-                echo -e "* Xcode will open with your current download (wait for it)\n"
                 sleep 2
                 xed .
                 echo -e "\nShell Script Completed\n"
@@ -369,7 +371,6 @@ then
     echo -e "\n\n--------------------------------\n\n"
     echo -e "Downloading Loop Follow Script\n"
     echo -e "\n--------------------------------\n\n"
-    rm ./BuildLoopFollow.sh
     curl -fsSLo ./BuildLoopFollow.sh https://raw.githubusercontent.com/jonfawcett/LoopFollow/Main/BuildLoopFollow.sh
     echo -e "\n\n\n\n"
     source ./BuildLoopFollow.sh
@@ -407,7 +408,6 @@ else
                 echo -e "\n--------------------------------\n"
                 echo -e "Downloading Derived Data Script"
                 echo -e "\n--------------------------------\n"
-                rm ./CleanCartDerived.sh
                 curl -fsSLo ./CleanCartDerived.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/CleanCartDerived.sh
                 echo -e "\n\n\n\n"
                 source ./CleanCartDerived.sh
@@ -417,7 +417,6 @@ else
                 echo -e "\n--------------------------------\n"
                 echo -e "Downloading Xcode Cleanup Script"
                 echo -e "\n--------------------------------\n"
-                rm ./XcodeClean.sh
                 curl -fsSLo ./XcodeClean.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/XcodeClean.sh
                 echo -e "\n\n\n\n"
                 source ./XcodeClean.sh
@@ -427,7 +426,6 @@ else
                 echo -e "\n--------------------------------\n"
                 echo -e "Downloading Profiles and Derived Data Script"
                 echo -e "\n--------------------------------\n"
-                rm ./CleanProfCartDerived.sh
                 curl -fsSLo ./CleanProfCartDerived.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/CleanProfCartDerived.sh
                 echo -e "\n\n\n\n"
                 source ./CleanProfCartDerived.sh

--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -139,28 +139,32 @@ function report_persistent_config_override() {
     echo -e "   with no slashes at the beginning of the line"
     echo -e "   your targets will be automatically signed"
     echo -e "Any line that starts with // is ignored"
-    echo -e "If ID is wrong - you should manually edit the file or delete the file now\n"
+    echo -e "  If ID is OK, hit return"
+    echo -e "  If ID is not OK, you can edit the file\n"
     return_when_ready
 }
 
 function create_persistent_config_override() {
-    echo -e "The Apple Developer page will open"
-    echo -e "* Log in to the page and note your 10-character Team ID"
-    echo -e " * If the Memebship page does not show, you may need to select it"
+    echo -e "\n--------------------------------\n"
+    echo -e "The Apple Developer page will open when you hit return"
+    echo -e " * Log in if needed"
+    echo -e " * If the Membership page does not show, you may need to select it"
+    echo -e "     Your Apple Developer ID is the 10-character Team ID"
     echo -e " * If you already have your account open in your browser, you may need to go to the already opened page"
     echo -e " * Once you get your ID, return to terminal window"
     echo -e "This is the page that will open:"
     echo -e "   https://developer.apple.com/account/#!/membership\n"
     return_when_ready
     open "https://developer.apple.com/account/#!/membership"
-    echo -e " * Click in terminal window\n"
+    echo -e "\n * Click in terminal window"
     read -p "Enter the ID and return: " devID
+    echo -e "\n--------------------------------\n"
     if [ ${#devID} -ne 10 ]; then
         echo -e "Something was wrong with entry"
         echo -e "You can manually sign each target in Xcode"
     else 
         echo -e "Creating ~/Downloads/BuildLoop/LoopConfigOverride.xcconfig"
-        echo -e "   with your Apple Developer ID"
+        echo -e "   with your Apple Developer ID\n"
         cp -p LoopWorkspace/LoopConfigOverride.xcconfig ..
         echo -e "LOOP_DEVELOPMENT_TEAM = ${devID}" >> ../LoopConfigOverride.xcconfig
         report_persistent_config_override
@@ -273,7 +277,6 @@ if [ "$WHICH" = "Loop" ]; then
         esac
     done
 
-    echo -e "\n\n\n\n"
     LOOP_DIR=~/Downloads/BuildLoop/$FOLDERNAME-$LOOP_BUILD
     if [ ${FRESH_CLONE} == 1 ]; then
         mkdir $LOOP_DIR

--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -178,7 +178,7 @@ function create_persistent_config_override() {
         cp -p LoopWorkspace/LoopConfigOverride.xcconfig ..
         echo -e "LOOP_DEVELOPMENT_TEAM = ${devID}" >> ../LoopConfigOverride.xcconfig
         report_persistent_config_override
-        echo -e "\nThe next time you build, this permanent file with automatically sign your targets"
+        echo -e "\nXcode uses the permanent file to automatically sign your targets"
     fi
 }
 

--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -84,7 +84,7 @@ function initial_greeting() {
     echo -e "  and do so at your own risk.\n"
     echo -e "${NC}If you find the font too small to read comfortably"
     echo -e "  Hold down the CMD key and hit + (or -)"
-    echo -e "  to increase (decrease) size\n"
+    echo -e "  to increase (decrease) size"
     choose_or_cancel
 }
 
@@ -105,8 +105,8 @@ function exit_message() {
 }
 
 function choose_or_cancel() {
-    echo -e "Type a number from the list below and return to proceed."
-    echo -e "${RED}${BOLD}  To cancel, any entry not in list also works\n${NC}"
+    echo -e "\nType a number from the list below and return to proceed."
+    echo -e "${RED}${BOLD}  To cancel, any entry not in list also works${NC}"
     echo -e "\n--------------------------------\n"
 }
 
@@ -227,7 +227,6 @@ echo -e "      You will be asked to choose from Loop or FreeAPS"
 echo -e "  2 Download and build LoopFollow"
 echo -e "  3 Prepare your computer using a Utility Script"
 echo -e "     when updating your computer or an app"
-echo -e "\n--------------------------------\n"
 choose_or_cancel
 options=("Build Loop" "Build LoopFollow" "Utility Scripts" "Cancel")
 select opt in "${options[@]}"
@@ -266,10 +265,17 @@ if [ "$WHICH" = "Loop" ]; then
         BRANCH_LOOP=dev
         BRANCH_FREE=freeaps_dev
         LOOPCONFIGOVERRIDE_VALID=1
-        echo -e "\n ${RED}${BOLD}You are running the script with a -d flag${NC}\n"
+        echo -e "\n ${RED}${BOLD}You are running the script for the development version${NC}\n"
         echo -e " -- If you choose Loop,    branch is ${RED}${BOLD}${BRANCH_LOOP}${NC}"
         echo -e " -- If you choose FreeAPS, branch is ${RED}${BOLD}${BRANCH_FREE}${NC}\n"
+        echo -e " ${RED}${BOLD}Be aware that a development version may require frequent rebuilds${NC}\n"
+        echo -e " If you have not read this section of LoopDocs - please review before continuing"
+        echo -e "    https://loopkit.github.io/loopdocs/faqs/branch-faqs/#loop-development"
     else
+        echo -e "\n ${RED}${BOLD}You are running the script for the released version${NC}\n"
+        echo -e "  These webpages will tell you the date of the last release for:"
+        echo -e "  Loop:    https://github.com/LoopKit/Loop/releases"
+        echo -e "  FreeAPS: https://github.com/loopnlearn/LoopWorkspace/releases"
         BRANCH_LOOP=master
         BRANCH_FREE=freeaps
         LOOPCONFIGOVERRIDE_VALID=0
@@ -318,8 +324,7 @@ if [ "$WHICH" = "Loop" ]; then
     echo -e "🛑 Please check for errors in the window above before proceeding."
     echo -e "   If there are no errors listed, code has successfully downloaded.\n"
     echo -e "Type 1 and return to continue if and ONLY if"
-    echo -e "  there are no errors (scroll up in terminal window to look for the word error)\n"
-    #echo -e "${RED}${BOLD}  Any entry (other than 1) cancels\n${NC}"
+    echo -e "  there are no errors (scroll up in terminal window to look for the word error)"
     choose_or_cancel
     options=("Continue" "Cancel")
     select opt in "${options[@]}"
@@ -334,7 +339,7 @@ if [ "$WHICH" = "Loop" ]; then
                         # make sure the LoopConfigOverride.xcconfig exists in clone
                         if [ -e LoopWorkspace/LoopConfigOverride.xcconfig ]; then
                             echo -e "Choose to enter Apple Developer ID or wait and Sign Manually (later in Xcode)"
-                            echo -e "\nIf you choose Apple Developer ID, script will help you find it\n"
+                            echo -e "\nIf you choose Apple Developer ID, script will help you find it"
                             choose_or_cancel
                             options=("Enter Apple Developer ID" "Sign Manually" "Cancel")
                             select opt in "${options[@]}"
@@ -362,7 +367,7 @@ if [ "$WHICH" = "Loop" ]; then
                     fi
                     echo -e "\n--------------------------------\n"
                 fi
-                echo -e "The following items will open (when you are ready)"
+                echo -e "\nThe following items will open (when you are ready)"
                 echo -e "* Webpage with abbreviated build steps (Loop and Learn)"
                 echo -e "* Webpage with detailed build steps (LoopDocs)"
                 echo -e "* Xcode ready to prep your current download for build\n"
@@ -431,7 +436,7 @@ else
     echo -e "      this action configures you to have a full year"
     echo -e "      before you are forced to rebuild your app."
     echo -e "\n--------------------------------\n"
-    echo -e "${RED}${BOLD}You may need to scroll up in the terminal to see details about options${NC}\n"
+    echo -e "${RED}${BOLD}You may need to scroll up in the terminal to see details about options${NC}"
     choose_or_cancel
     options=("Clean Derived Data" "Xcode Cleanup (The Big One)" "Clean Profiles & Derived Data" "Cancel")
     select opt in "${options[@]}"

--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -36,24 +36,24 @@ BRANCH_TYPE=master
 while getopts 'dht' OPTION; do
    case "${OPTION}" in
       h) # display Help
-         echo "Optional Flags:"
-         echo "  -h : print this help message"
-         echo "  -t : sets FRESH_CLONE=0"
-         echo "  -d : use dev branches (not master)"
+         echo -e "Optional Flags:"
+         echo -e "  -h : print this help message"
+         echo -e "  -t : sets FRESH_CLONE=0"
+         echo -e "  -d : use dev branches (not master)"
          exit;;
       t) # Do not download a fresh clone - useful for testing
-         echo "  -t flag, sets FRESH_CLONE=0"
+         echo -e "  -t flag, sets FRESH_CLONE=0"
          FRESH_CLONE=0
          sleep 1
          ;;
       d) # set flag to download dev branches
-         echo "  -d flag, sets BRANCH_TYPE=dev"
+         echo -e "  -d flag, sets BRANCH_TYPE=dev"
          BRANCH_TYPE=dev
          LOOP_BUILD="dev"-${LOOP_BUILD}
          sleep 1
          ;;
       \?) # Invalid option
-         echo "Error: Invalid option"
+         echo -e "Error: Invalid option"
          exit;;
    esac
 done
@@ -76,23 +76,23 @@ curl -fsSLo ${SCRIPT_DIR}/BuildLoop.sh https://raw.githubusercontent.com/loopnle
 
 # clear
 
-echo "${RED}${BOLD}\n\n--------------------------------\n\n"
-echo "IMPORTANT\n"
-echo "Please understand that this project:\n"
-echo "- Is Open Source software"
-echo "- Is not \"approved\" for therapy\n"
-echo "And that:"
-echo "- You take full responsibility for"
-echo "  reading and understanding the documenation"
-echo "  (LoopsDocs is found at https://loopdocs.org)"
-echo "  before building and running this system,"
-echo "  and do so at your own risk.\n"
-echo "${NC}If you find the font too small to read comfortably"
-echo "  Hold down the CMD key and hit + (or -)"
-echo "  to increase (decrease) size\n"
-echo "${RED}${BOLD}By typing 1 and ENTER, you indicate you agree"
-echo "  Any other entry cancels"
-echo "\n--------------------------------\n"
+echo -e "${RED}${BOLD}\n\n--------------------------------\n\n"
+echo -e "IMPORTANT\n"
+echo -e "Please understand that this project:\n"
+echo -e "- Is Open Source software"
+echo -e "- Is not \"approved\" for therapy\n"
+echo -e "And that:"
+echo -e "- You take full responsibility for"
+echo -e "  reading and understanding the documenation"
+echo -e "  (LoopsDocs is found at https://loopdocs.org)"
+echo -e "  before building and running this system,"
+echo -e "  and do so at your own risk.\n"
+echo -e "${NC}If you find the font too small to read comfortably"
+echo -e "  Hold down the CMD key and hit + (or -)"
+echo -e "  to increase (decrease) size\n"
+echo -e "${RED}${BOLD}By typing 1 and ENTER, you indicate you agree"
+echo -e "  Any other entry cancels"
+echo -e "\n--------------------------------\n"
 options=("Agree")
 select opt in "${options[@]}"
 do
@@ -101,28 +101,28 @@ do
             break
             ;;
         *)
-            echo "\n${RED}${BOLD}User did not agree to terms of use.${NC}\n\n";
-            echo "You can press the up arrow ⬆️  on the keyboard"
-            echo "    and return to repeat script from beginning.\n\n";
+            echo -e "\n${RED}${BOLD}User did not agree to terms of use.${NC}\n\n";
+            echo -e "You can press the up arrow ⬆️  on the keyboard"
+            echo -e "    and return to repeat script from beginning.\n\n";
             exit 0
             break
             ;;
     esac
 done
 
-echo "${NC}\n\n\n\n"
+echo -e "${NC}\n\n\n\n"
 
-echo "\n--------------------------------\n"
-echo "${BOLD}Welcome to the Loop and Learn\n  Build-Select Script\n${NC}"
-echo "This script will assist you in one of these actions:"
-echo "  1 Download and build Loop"
-echo "      You will be asked to choose from Loop or FreeAPS"
-echo "  2 Download and build LoopFollow"
-echo "  3 Prepare your computer using a Utility Script"
-echo "     when updating your computer or an app"
-echo "\n--------------------------------\n"
-echo "Type a number from the list below and return to proceed."
-echo "${RED}${BOLD}  Any other entry cancels\n${NC}"
+echo -e "\n--------------------------------\n"
+echo -e "${BOLD}Welcome to the Loop and Learn\n  Build-Select Script\n${NC}"
+echo -e "This script will assist you in one of these actions:"
+echo -e "  1 Download and build Loop"
+echo -e "      You will be asked to choose from Loop or FreeAPS"
+echo -e "  2 Download and build LoopFollow"
+echo -e "  3 Prepare your computer using a Utility Script"
+echo -e "     when updating your computer or an app"
+echo -e "\n--------------------------------\n"
+echo -e "Type a number from the list below and return to proceed."
+echo -e "${RED}${BOLD}  Any other entry cancels\n${NC}"
 options=("Build Loop" "Build LoopFollow" "Utility Scripts")
 select opt in "${options[@]}"
 do
@@ -140,39 +140,39 @@ do
             break
             ;;
         *)
-            echo "\n${RED}${BOLD}User cancelled - selected an invalid option${NC}\n"
-            echo "You can press the up arrow ⬆️  on the keyboard"
-            echo "    and return to repeat script from beginning.\n\n";
+            echo -e "\n${RED}${BOLD}User cancelled - selected an invalid option${NC}\n"
+            echo -e "You can press the up arrow ⬆️  on the keyboard"
+            echo -e "    and return to repeat script from beginning.\n\n";
             exit 0
             break
             ;;
     esac
 done
 
-echo "\n\n\n\n"
+echo -e "\n\n\n\n"
 
 if [ "$WHICH" = "Loop" ]
 then
-    echo "\n--------------------------------\n"
-    echo "Before you begin, please ensure that you have Xcode installed,"
-    echo "  Xcode command line tools installed, and"
-    echo "  your phone is plugged into your computer\n"
-    echo "Please select which version of Loop you would like to download and build.\n"
-    echo "Type a number from the list below and return"
+    echo -e "\n--------------------------------\n"
+    echo -e "Before you begin, please ensure that you have Xcode installed,"
+    echo -e "  Xcode command line tools installed, and"
+    echo -e "  your phone is plugged into your computer\n"
+    echo -e "Please select which version of Loop you would like to download and build.\n"
+    echo -e "Type a number from the list below and return"
     if [ "$BRANCH_TYPE" = "dev" ]
     then
         BRANCH_LOOP=dev
         BRANCH_FREE=freeaps_dev
         LOOPCONFIGOVERRIDE_VALID=1
-        echo "\n ${RED}${BOLD}You are running the script with a -d flag${NC}\n"
-        echo " -- If you choose Loop,    branch is ${RED}${BOLD}${BRANCH_LOOP}${NC}"
-        echo " -- If you choose FreeAPS, branch is ${RED}${BOLD}${BRANCH_FREE}${NC}\n"
+        echo -e "\n ${RED}${BOLD}You are running the script with a -d flag${NC}\n"
+        echo -e " -- If you choose Loop,    branch is ${RED}${BOLD}${BRANCH_LOOP}${NC}"
+        echo -e " -- If you choose FreeAPS, branch is ${RED}${BOLD}${BRANCH_FREE}${NC}\n"
     else
         BRANCH_LOOP=master
         BRANCH_FREE=freeaps
         LOOPCONFIGOVERRIDE_VALID=0
     fi
-    echo "${RED}${BOLD}  Any other entry cancels\n${NC}"
+    echo -e "${RED}${BOLD}  Any other entry cancels\n${NC}"
     options=("Loop" "FreeAPS")
     select opt in "${options[@]}"
     do
@@ -190,38 +190,38 @@ then
                 break
                 ;;
             *)
-                echo "\n${RED}${BOLD}User cancelled - selected an invalid option${NC}\n"
-                echo "You can press the up arrow ⬆️  on the keyboard"
-                echo "    and return to repeat script from beginning.\n\n";
+                echo -e "\n${RED}${BOLD}User cancelled - selected an invalid option${NC}\n"
+                echo -e "You can press the up arrow ⬆️  on the keyboard"
+                echo -e "    and return to repeat script from beginning.\n\n";
                 exit 0
                 break
                 ;;
         esac
     done
 
-    echo "\n\n\n\n"
+    echo -e "\n\n\n\n"
     LOOP_DIR=~/Downloads/BuildLoop/$FOLDERNAME-$LOOP_BUILD
     if [ ${FRESH_CLONE} == 1 ]
     then
         mkdir $LOOP_DIR
         cd $LOOP_DIR
     fi
-    echo "\n\n\n\n"
-    echo "\n--------------------------------\n"
+    echo -e "\n\n\n\n"
+    echo -e "\n--------------------------------\n"
     if [ ${FRESH_CLONE} == 1 ]
     then
-        echo " -- Downloading ${FOLDERNAME} ${BRANCH} to your Downloads folder --"
-        echo "      ${LOOP_DIR}\n"
-        echo "Issuing this command:"
-        echo "    git clone --branch=${BRANCH} --recurse-submodules ${REPO}"
+        echo -e " -- Downloading ${FOLDERNAME} ${BRANCH} to your Downloads folder --"
+        echo -e "      ${LOOP_DIR}\n"
+        echo -e "Issuing this command:"
+        echo -e "    git clone --branch=${BRANCH} --recurse-submodules ${REPO}"
         git clone --branch=$BRANCH --recurse-submodules $REPO
     fi
-    echo "\n--------------------------------\n"
-    echo "🛑 Please check for errors in the window above before proceeding."
-    echo "   If there are no errors listed, code has successfully downloaded.\n"
-    echo "Type 1 and return to continue if and ONLY if"
-    echo "  there are no errors (scroll up in terminal window to look for the word error)\n"
-    echo "${RED}${BOLD}  Any entry (other than 1) cancels\n${NC}"
+    echo -e "\n--------------------------------\n"
+    echo -e "🛑 Please check for errors in the window above before proceeding."
+    echo -e "   If there are no errors listed, code has successfully downloaded.\n"
+    echo -e "Type 1 and return to continue if and ONLY if"
+    echo -e "  there are no errors (scroll up in terminal window to look for the word error)\n"
+    echo -e "${RED}${BOLD}  Any entry (other than 1) cancels\n${NC}"
 
 
     options=("Continue")
@@ -231,63 +231,63 @@ then
             "Continue")
                 if [ ${LOOPCONFIGOVERRIDE_VALID} == 1 ]
                 then
-                    echo "\n--------------------------------\n"
-                    # echo "Checking status of persistent override file"
+                    echo -e "\n--------------------------------\n"
+                    # echo -e "Checking status of persistent override file"
                     # determine if the persistent file exists
                     # if so, remind user
                     if [ -e ../LoopConfigOverride.xcconfig ]
                     then
-                        echo "You have a persistent override file:"
-                        echo "   ~/Downloads/BuildLoop/LoopConfigOverride.xcconfig"
-                        echo "The last 3 lines of that file are shown next:\n"
+                        echo -e "You have a persistent override file:"
+                        echo -e "   ~/Downloads/BuildLoop/LoopConfigOverride.xcconfig"
+                        echo -e "The last 3 lines of that file are shown next:\n"
                         tail -3 ../LoopConfigOverride.xcconfig
-                        echo "\nIf the last line has your Apple Developer ID"
-                        echo "   with no slashes at the beginning of the line"
-                        echo "   your targets will be automatically signed"
-                        echo "Any line that starts with // is ignored"
-                        echo "If ID is wrong - you can manually edit the file now\n"
+                        echo -e "\nIf the last line has your Apple Developer ID"
+                        echo -e "   with no slashes at the beginning of the line"
+                        echo -e "   your targets will be automatically signed"
+                        echo -e "Any line that starts with // is ignored"
+                        echo -e "If ID is wrong - you can manually edit the file now\n"
                         read -p "Return when ready to continue  " dummy
                     else
                         # make sure the LoopConfigOverride.xcconfig exists in clone
                         if [ -e LoopWorkspace/LoopConfigOverride.xcconfig ]
                         then
-                            echo "Choose to enter Apple ID or wait and Sign Manually (later in Xcode)"
-                            echo "\nIf you choose Apple ID, script will help you find it\n"
+                            echo -e "Choose to enter Apple ID or wait and Sign Manually (later in Xcode)"
+                            echo -e "\nIf you choose Apple ID, script will help you find it\n"
                             options=("Enter Apple ID" "Sign Manually")
                             select opt in "${options[@]}"
                             do
                                 case $opt in
                                     "Enter Apple ID")
-                                        echo "The Apple Developer page will open"
-                                        echo "* Log in to the page and note your 10-character Team ID"
-                                        echo " * If the Memebship page does not show, you may need to select it"
-                                        echo " * If you already have your account open in your browser, you may need to go to the already opened page"
-                                        echo " * For reference, this is the page that will open:"
-                                        echo "   https://developer.apple.com/account/#!/membership\n"
-                                        echo "Then, return to terminal window"
+                                        echo -e "The Apple Developer page will open"
+                                        echo -e "* Log in to the page and note your 10-character Team ID"
+                                        echo -e " * If the Memebship page does not show, you may need to select it"
+                                        echo -e " * If you already have your account open in your browser, you may need to go to the already opened page"
+                                        echo -e " * For reference, this is the page that will open:"
+                                        echo -e "   https://developer.apple.com/account/#!/membership\n"
+                                        echo -e "Then, return to terminal window"
                                         open "https://developer.apple.com/account/#!/membership"
                                         read -p "Enter the ID and return: " devID
                                         if [ ${#devID} -ne 10 ]
                                         then
-                                            echo "Something was wrong with entry"
-                                            echo "You can manually edit the file later or"
-                                            echo "  just sign each target in Xcode"
+                                            echo -e "Something was wrong with entry"
+                                            echo -e "You can manually edit the file later or"
+                                            echo -e "  just sign each target in Xcode"
                                         else 
-                                            echo "Copying LoopConfigOverride.xcconfig to ~/Downloads/BuildLoop"
-                                            echo "Adding a new line with your Apple Developer ID"
+                                            echo -e "Copying LoopConfigOverride.xcconfig to ~/Downloads/BuildLoop"
+                                            echo -e "Adding a new line with your Apple Developer ID"
                                             cp -p LoopWorkspace/LoopConfigOverride.xcconfig ..
-                                            echo "LOOP_DEVELOPMENT_TEAM = ${devID}" >> ../LoopConfigOverride.xcconfig
-                                            echo "You now have a persistent override file:"
-                                            echo "   ~/Downloads/BuildLoop/LoopConfigOverride.xcconfig"
-                                            echo "The last 3 lines of that file are shown next:\n"
+                                            echo -e "LOOP_DEVELOPMENT_TEAM = ${devID}" >> ../LoopConfigOverride.xcconfig
+                                            echo -e "You now have a persistent override file:"
+                                            echo -e "   ~/Downloads/BuildLoop/LoopConfigOverride.xcconfig"
+                                            echo -e "The last 3 lines of that file are shown next:\n"
                                             tail -3 ../LoopConfigOverride.xcconfig
-                                            echo "\nIf the last line has your Apple Developer ID"
-                                            echo "   with no slashes at the beginning of the line"
-                                            echo "   your targets will be automatically signed"
-                                            echo "Any line that starts with // is ignored"
-                                            echo "If ID is wrong - you can manually edit the file now\n"
+                                            echo -e "\nIf the last line has your Apple Developer ID"
+                                            echo -e "   with no slashes at the beginning of the line"
+                                            echo -e "   your targets will be automatically signed"
+                                            echo -e "Any line that starts with // is ignored"
+                                            echo -e "If ID is wrong - you can manually edit the file now\n"
                                             read -p "Return when ready to continue  " dummy
-                                            echo "\nThe next time you build, this permanent file with automatically sign your targets"
+                                            echo -e "\nThe next time you build, this permanent file with automatically sign your targets"
                                         fi
                                         break
                                         ;;
@@ -295,50 +295,50 @@ then
                                         break
                                         ;;
                                       *) # Invalid option
-                                         echo "Error: Invalid option"
+                                         echo -e "Error: Invalid option"
                                          exit;;
                                 esac
                             done
                         else
-                            echo "This project does not have a persistent override file"
-                            echo "You must sign the targets individually"
+                            echo -e "This project does not have a persistent override file"
+                            echo -e "You must sign the targets individually"
                             LOOPCONFIGOVERRIDE_VALID=0
                         fi
                     fi
-                    echo "\n--------------------------------\n"
+                    echo -e "\n--------------------------------\n"
                 fi
                 # the helper page displayed depends on validity of persistent override
                 if [ ${LOOPCONFIGOVERRIDE_VALID} == 1 ]
                 then
                     # change this page to the one (not yet written) for persistent override
-                    echo "* The Loop and Learn webpage with abbreviated build steps will be displayed in your browser"
+                    echo -e "* The Loop and Learn webpage with abbreviated build steps will be displayed in your browser"
                     sleep 2
                     open https://www.loopandlearn.org/workspace-build-loop
                 else
-                    echo "* The Loop and Learn webpage with abbreviated build steps will be displayed in your browser"
+                    echo -e "* The Loop and Learn webpage with abbreviated build steps will be displayed in your browser"
                     sleep 2
                     open https://www.loopandlearn.org/workspace-build-loop
                 fi
-                echo "* The LoopDocs webpage with detailed build steps will be displayed in your browser"
+                echo -e "* The LoopDocs webpage with detailed build steps will be displayed in your browser"
                 sleep 2
                 open "https://loopkit.github.io/loopdocs/build/step14/#prepare-to-build"
                 cd LoopWorkspace
                 sleep 2
-                echo "* Xcode will open with your current download (wait for it)\n"
+                echo -e "* Xcode will open with your current download (wait for it)\n"
                 sleep 2
                 xed .
-                echo "\nShell Script Completed\n"
-                echo " * You may close the terminal window now if you want"
-                echo "  or"
-                echo " * You can press the up arrow ⬆️  on the keyboard"
-                echo "    and return to repeat script from beginning.\n\n";
+                echo -e "\nShell Script Completed\n"
+                echo -e " * You may close the terminal window now if you want"
+                echo -e "  or"
+                echo -e " * You can press the up arrow ⬆️  on the keyboard"
+                echo -e "    and return to repeat script from beginning.\n\n";
                 exit 0
                 break
                 ;;
             *)
-                echo "\n${RED}${BOLD}User cancelled - selected an invalid option${NC}\n"
-                echo "* You can press the up arrow ⬆️  on the keyboard"
-                echo "    and return to repeat script from beginning.\n\n";
+                echo -e "\n${RED}${BOLD}User cancelled - selected an invalid option${NC}\n"
+                echo -e "* You can press the up arrow ⬆️  on the keyboard"
+                echo -e "    and return to repeat script from beginning.\n\n";
                 exit 0
                 break
                 ;;
@@ -349,78 +349,78 @@ elif [ "$WHICH" = "LoopFollow" ]
 then
     # Note that BuildLoopFollow.sh has a warning about Xcode and phone, not needed here
     cd $LOOP_DIR/Scripts
-    echo "\n\n--------------------------------\n\n"
-    echo "Downloading Loop Follow Script\n"
-    echo "\n--------------------------------\n\n"
+    echo -e "\n\n--------------------------------\n\n"
+    echo -e "Downloading Loop Follow Script\n"
+    echo -e "\n--------------------------------\n\n"
     rm ./BuildLoopFollow.sh
     curl -fsSLo ./BuildLoopFollow.sh https://raw.githubusercontent.com/jonfawcett/LoopFollow/Main/BuildLoopFollow.sh
-    echo "\n\n\n\n"
+    echo -e "\n\n\n\n"
     source ./BuildLoopFollow.sh
 else
     cd $LOOP_DIR/Scripts
-    echo "\n\n\n\n"
-    echo "\n--------------------------------\n"
-    echo "${BOLD}These utility scripts automate several cleanup actions${NC}"
-    echo "\n--------------------------------\n"
-    echo "1 ➡️  Clean Derived Data:\n"
-    echo "    This script is used to clean up data from old builds."
-    echo "    In other words, it frees up space on your disk."
-    echo "    Xcode should be closed when running this script.\n"
-    echo "2 ➡️  Xcode Cleanup (The Big One):\n"
-    echo "    This script clears even more disk space filled up by using Xcode."
-    echo "    It is typically used after uninstalling Xcode"
-    echo "      and before installing a new version of Xcode."
-    echo "    It can free up a substantial amount of disk space."
-    echo "\n    You might be directed to use this script to resolve a problem."
-    echo "\n${RED}${BOLD}    Beware that you might be required to fully uninstall"
-    echo "      and reinstall Xcode if you run this script with Xcode installed.\n${NC}"
-    echo "    Always a good idea to reboot your computer after Xcode Cleanup.\n"
-    echo "3 ➡️  Clean Profiles & Derived Data:\n"
-    echo "    For those with a paid Apple Developer ID,"
-    echo "      this action configures you to have a full year"
-    echo "      before you are forced to rebuild your app."
-    echo "\n--------------------------------\n"
-    echo "Type a number from the list below and return to proceed."
-    echo "${RED}${BOLD}  Any other entry - ENTER cancels\n"
-    echo "You may need to scroll up in the terminal to see details about options${NC}\n"
+    echo -e "\n\n\n\n"
+    echo -e "\n--------------------------------\n"
+    echo -e "${BOLD}These utility scripts automate several cleanup actions${NC}"
+    echo -e "\n--------------------------------\n"
+    echo -e "1 ➡️  Clean Derived Data:\n"
+    echo -e "    This script is used to clean up data from old builds."
+    echo -e "    In other words, it frees up space on your disk."
+    echo -e "    Xcode should be closed when running this script.\n"
+    echo -e "2 ➡️  Xcode Cleanup (The Big One):\n"
+    echo -e "    This script clears even more disk space filled up by using Xcode."
+    echo -e "    It is typically used after uninstalling Xcode"
+    echo -e "      and before installing a new version of Xcode."
+    echo -e "    It can free up a substantial amount of disk space."
+    echo -e "\n    You might be directed to use this script to resolve a problem."
+    echo -e "\n${RED}${BOLD}    Beware that you might be required to fully uninstall"
+    echo -e "      and reinstall Xcode if you run this script with Xcode installed.\n${NC}"
+    echo -e "    Always a good idea to reboot your computer after Xcode Cleanup.\n"
+    echo -e "3 ➡️  Clean Profiles & Derived Data:\n"
+    echo -e "    For those with a paid Apple Developer ID,"
+    echo -e "      this action configures you to have a full year"
+    echo -e "      before you are forced to rebuild your app."
+    echo -e "\n--------------------------------\n"
+    echo -e "Type a number from the list below and return to proceed."
+    echo -e "${RED}${BOLD}  Any other entry - ENTER cancels\n"
+    echo -e "You may need to scroll up in the terminal to see details about options${NC}\n"
     options=("Clean Derived Data" "Xcode Cleanup (The Big One)" "Clean Profiles & Derived Data")
     select opt in "${options[@]}"
     do
         case $opt in
             "Clean Derived Data")
-                echo "\n--------------------------------\n"
-                echo "Downloading Derived Data Script"
-                echo "\n--------------------------------\n"
+                echo -e "\n--------------------------------\n"
+                echo -e "Downloading Derived Data Script"
+                echo -e "\n--------------------------------\n"
                 rm ./CleanCartDerived.sh
                 curl -fsSLo ./CleanCartDerived.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/CleanCartDerived.sh
-                echo "\n\n\n\n"
+                echo -e "\n\n\n\n"
                 source ./CleanCartDerived.sh
                 break
                 ;;
             "Xcode Cleanup (The Big One)")
-                echo "\n--------------------------------\n"
-                echo "Downloading Xcode Cleanup Script"
-                echo "\n--------------------------------\n"
+                echo -e "\n--------------------------------\n"
+                echo -e "Downloading Xcode Cleanup Script"
+                echo -e "\n--------------------------------\n"
                 rm ./XcodeClean.sh
                 curl -fsSLo ./XcodeClean.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/XcodeClean.sh
-                echo "\n\n\n\n"
+                echo -e "\n\n\n\n"
                 source ./XcodeClean.sh
                 break
                 ;;
             "Clean Profiles & Derived Data")
-                echo "\n--------------------------------\n"
-                echo "Downloading Profiles and Derived Data Script"
-                echo "\n--------------------------------\n"
+                echo -e "\n--------------------------------\n"
+                echo -e "Downloading Profiles and Derived Data Script"
+                echo -e "\n--------------------------------\n"
                 rm ./CleanProfCartDerived.sh
                 curl -fsSLo ./CleanProfCartDerived.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/CleanProfCartDerived.sh
-                echo "\n\n\n\n"
+                echo -e "\n\n\n\n"
                 source ./CleanProfCartDerived.sh
                 break
                 ;;
             *)
-                echo "\n${RED}${BOLD}User cancelled - selected an invalid option${NC}\n"
-                echo "You can press the up arrow ⬆️  on the keyboard"
-                echo "    and return to repeat script from beginning.\n\n";
+                echo -e "\n${RED}${BOLD}User cancelled - selected an invalid option${NC}\n"
+                echo -e "You can press the up arrow ⬆️  on the keyboard"
+                echo -e "    and return to repeat script from beginning.\n\n";
                 exit 0
                 break
                 ;;

--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -48,6 +48,9 @@ while getopts 'dht' OPTION; do
       d) # set flag to download dev branches
          echo -e "  -d flag, sets BRANCH_TYPE=dev"
          BRANCH_TYPE=dev
+         echo -e ${LOOP_BUILD}
+         LOOP_BUILD="dev"-${LOOP_BUILD}
+         echo -e ${LOOP_BUILD}
          sleep 1
          ;;
       \?) # Invalid option
@@ -81,13 +84,12 @@ then
     mkdir $SCRIPT_DIR
 fi
 
-# make a copy of this script in script folder
-cd ${SCRIPT_DIR}
-if [ -e ./BuildLoop.sh ]
+# make a copy of this script in script directory
+if [ -e ${SCRIPT_DIR}/BuildLoop.sh ]
 then
-    rm ./BuildLoop.sh
+    rm ${SCRIPT_DIR}/BuildLoop.sh
 fi
-curl -fsSLo ./BuildLoop.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/BuildLoop.sh
+curl -fsSLo ${SCRIPT_DIR}/BuildLoop.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/BuildLoop.sh
 
 # clear
 
@@ -176,12 +178,12 @@ then
     echo -e "Please select which version of Loop you would like to download and build.\n"
     echo -e "Type a number from the list below and return"
     echo -e "${RED}${BOLD}  Any other entry cancels\n${NC}"
-    options=("Loop Master" "FreeAPS")
+    options=("Loop" "FreeAPS")
     select opt in "${options[@]}"
     do
         case $opt in
-            "Loop Master")
-                FOLDERNAME=Loop-Master
+            "Loop")
+                FOLDERNAME=Loop
                 REPO=https://github.com/LoopKit/LoopWorkspace
                 BRANCH=$BRANCH_LOOP
                 break

--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -26,6 +26,9 @@ FRESH_CLONE=1
 #   Default value is master
 BRANCH_TYPE=master
 
+# Prepare date-time stamp for folder
+LOOP_BUILD=$(date +'%y%m%d-%H%M')
+
 function usage() {
     echo -e "Allowed arguments:"
     echo -e "  -h or --help : print this help message"
@@ -109,7 +112,6 @@ function configure_folders_download_script() {
     # downloads copy of this script (main branch)
     ############################################################
 
-    LOOP_BUILD=$(date +'%y%m%d-%H%M')
     LOOP_DIR=~/Downloads/BuildLoop/
     SCRIPT_DIR=~/Downloads/BuildLoop/Scripts
 

--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -39,7 +39,7 @@ function usage() {
 }
 
 ############################################################
-# Process flags, the input options as positional parameters
+# Process flags, input options as positional parameters
 ############################################################
 while [ "$1" != "" ]; do
     case $1 in
@@ -50,13 +50,11 @@ while [ "$1" != "" ]; do
         -t | --test )  # Do not download clone - useful for testing
             echo -e "  -t or --test selected, sets FRESH_CLONE=0"
             FRESH_CLONE=0
-            sleep 1
             ;;
         -d | --dev )  # select dev branches
             echo -e "  -d or --dev selected, sets BRANCH_TYPE=dev"
             BRANCH_TYPE=dev
             LOOP_BUILD="dev"-${LOOP_BUILD}
-            sleep 1
             ;;
         * )  # argument not recognized
             echo -e "\n${RED}${BOLD}Input argument not recognized${NC}\n"
@@ -66,8 +64,10 @@ while [ "$1" != "" ]; do
     shift
 done
 
+sleep 1
+
 ############################################################
-# Define the rest of the functions (usage above):
+# Define the rest of the functions (usage defined above):
 ############################################################
 
 function initial_greeting() {
@@ -114,11 +114,17 @@ function return_when_ready() {
     read -p "Return when ready to continue  " dummy
 }
 
+############################################################
+# function configure_folders_download_script
+#
+# defines folder names and default locations
+# downloads copy of this script (main branch)
+#
+# This function call should be AFTER user accepts terms of use
+#    DO NOT MOVE call to this function before that question
+#
+############################################################
 function configure_folders_download_script() {
-    ############################################################
-    # defines folder names and default locations
-    # downloads copy of this script (main branch)
-    ############################################################
 
     LOOP_DIR=~/Downloads/BuildLoop/
     SCRIPT_DIR=~/Downloads/BuildLoop/Scripts
@@ -176,10 +182,14 @@ function create_persistent_config_override() {
     fi
 }
 
+############################################################
+# End of functions used by script
+############################################################
 
-##############################################
-#  BuildLoop script continues using functions
-##############################################
+
+############################################################
+#  BuildLoop script continues using functions defined above
+############################################################
 
 # call function
 initial_greeting
@@ -203,6 +213,8 @@ do
 done
 
 # user agreed; call function
+#    DO NOT MOVE call to configure_folders_download_script
+#       before user agrees to terms of use
 configure_folders_download_script
 
 echo -e "${NC}\n\n\n\n"
@@ -351,9 +363,10 @@ if [ "$WHICH" = "Loop" ]; then
                     echo -e "\n--------------------------------\n"
                 fi
                 echo -e "The following items will open (when you are ready)"
-                echo -e "* The Loop and Learn webpage with abbreviated build steps"
-                echo -e "* The LoopDocs webpage with detailed build steps"
-                echo -e "* Xcode will open with your current download\n"
+                echo -e "* Webpage with abbreviated build steps (Loop and Learn)"
+                echo -e "* Webpage with detailed build steps (LoopDocs)"
+                echo -e "* Xcode ready to prep your current download for build\n"
+                echo -e "     Do not forget to select Loop(Workspace)\n"
                 return_when_ready
                 # the helper page displayed depends on validity of persistent override
                 if [ ${LOOPCONFIGOVERRIDE_VALID} == 1 ]; then
@@ -362,10 +375,10 @@ if [ "$WHICH" = "Loop" ]; then
                 else
                     open https://www.loopandlearn.org/workspace-build-loop
                 fi
-                sleep 4
+                sleep 5
                 open "https://loopkit.github.io/loopdocs/build/step14/#prepare-to-build"
                 cd LoopWorkspace
-                sleep 2
+                sleep 5
                 xed .
                 echo -e "\nShell Script Completed\n"
                 echo -e " * You may close the terminal window now if you want"

--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -1,4 +1,4 @@
-# !/bin/bash
+#!/bin/bash
 
 ############################################################
 # define some font styles and colors
@@ -85,13 +85,16 @@ function initial_greeting() {
     echo -e "${NC}If you find the font too small to read comfortably"
     echo -e "  Hold down the CMD key and hit + (or -)"
     echo -e "  to increase (decrease) size\n"
-    echo -e "${RED}${BOLD}By typing 1 and ENTER, you indicate you agree"
-    echo -e "  Any other entry cancels"
-    echo -e "\n--------------------------------\n"
+    choose_or_cancel
+}
+
+function cancel_entry() {
+    echo -e "\n${RED}${BOLD}User canceled${NC}\n"
+    exit_message
 }
 
 function invalid_entry() {
-    echo -e "\n${RED}${BOLD}User entered an invalid option${NC}\n"
+    echo -e "\n${RED}${BOLD}User canceled by entering an invalid option${NC}\n"
     exit_message
 }
 
@@ -103,7 +106,12 @@ function exit_message() {
 
 function choose_or_cancel() {
     echo -e "Type a number from the list below and return to proceed."
-    echo -e "${RED}${BOLD}  Any other entry cancels\n${NC}"
+    echo -e "${RED}${BOLD}  To cancel, any entry not in list also works\n${NC}"
+    echo -e "\n--------------------------------\n"
+}
+
+function return_when_ready() {
+    read -p "Return when ready to continue  " dummy
 }
 
 function configure_folders_download_script() {
@@ -124,10 +132,6 @@ function configure_folders_download_script() {
 
     # store a copy of this script in script directory
     curl -fsSLo ${SCRIPT_DIR}/BuildLoop.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/BuildLoop.sh
-}
-
-function return_when_ready() {
-    read -p "Return when ready to continue  " dummy
 }
 
 function report_persistent_config_override() {
@@ -180,17 +184,20 @@ function create_persistent_config_override() {
 # call function
 initial_greeting
 
-options=("Agree")
+options=("Agree" "Cancel")
 select opt in "${options[@]}"
 do
     case $opt in
         "Agree")
             break
             ;;
+        "Cancel")
+            echo -e "\n${RED}${BOLD}User did not agree to terms of use.${NC}\n\n";
+            exit_message
+            ;;
         *)
             echo -e "\n${RED}${BOLD}User did not agree to terms of use.${NC}\n\n";
             exit_message
-            break
             ;;
     esac
 done
@@ -210,7 +217,7 @@ echo -e "  3 Prepare your computer using a Utility Script"
 echo -e "     when updating your computer or an app"
 echo -e "\n--------------------------------\n"
 choose_or_cancel
-options=("Build Loop" "Build LoopFollow" "Utility Scripts")
+options=("Build Loop" "Build LoopFollow" "Utility Scripts" "Cancel")
 select opt in "${options[@]}"
 do
     case $opt in
@@ -226,9 +233,11 @@ do
             WHICH=UtilityScripts
             break
             ;;
+        "Cancel")
+            cancel_entry
+            ;;
         *)
             invalid_entry
-            break
             ;;
     esac
 done
@@ -254,7 +263,7 @@ if [ "$WHICH" = "Loop" ]; then
         LOOPCONFIGOVERRIDE_VALID=0
     fi
     choose_or_cancel
-    options=("Loop" "FreeAPS")
+    options=("Loop" "FreeAPS" "Cancel")
     select opt in "${options[@]}"
     do
         case $opt in
@@ -270,9 +279,11 @@ if [ "$WHICH" = "Loop" ]; then
                 BRANCH=$BRANCH_FREE
                 break
                 ;;
+            "Cancel")
+                cancel_entry
+                ;;
             *)
                 invalid_entry
-                break
                 ;;
         esac
     done
@@ -298,7 +309,7 @@ if [ "$WHICH" = "Loop" ]; then
     echo -e "  there are no errors (scroll up in terminal window to look for the word error)\n"
     #echo -e "${RED}${BOLD}  Any entry (other than 1) cancels\n${NC}"
     choose_or_cancel
-    options=("Continue")
+    options=("Continue" "Cancel")
     select opt in "${options[@]}"
     do
         case $opt in
@@ -313,7 +324,7 @@ if [ "$WHICH" = "Loop" ]; then
                             echo -e "Choose to enter Apple Developer ID or wait and Sign Manually (later in Xcode)"
                             echo -e "\nIf you choose Apple Developer ID, script will help you find it\n"
                             choose_or_cancel
-                            options=("Enter Apple Developer ID" "Sign Manually")
+                            options=("Enter Apple Developer ID" "Sign Manually" "Cancel")
                             select opt in "${options[@]}"
                             do
                                 case $opt in
@@ -324,9 +335,12 @@ if [ "$WHICH" = "Loop" ]; then
                                     "Sign Manually")
                                         break
                                         ;;
+                                    "Cancel")
+                                        cancel_entry
+                                        ;;
                                       *) # Invalid option
-                                         echo -e "Error: Invalid option"
-                                         exit;;
+                                         invalid_entry
+                                         ;;
                                 esac
                             done
                         else
@@ -336,20 +350,19 @@ if [ "$WHICH" = "Loop" ]; then
                     fi
                     echo -e "\n--------------------------------\n"
                 fi
-                echo -e "The following items will open (in a few seconds)"
-                echo -e "* The Loop and Learn webpage with abbreviated build steps will be displayed in your browser"
-                echo -e "* The LoopDocs webpage with detailed build steps will be displayed in your browser"
-                echo -e "* Xcode will open with your current download (wait for it)\n"
+                echo -e "The following items will open (when you are ready)"
+                echo -e "* The Loop and Learn webpage with abbreviated build steps"
+                echo -e "* The LoopDocs webpage with detailed build steps"
+                echo -e "* Xcode will open with your current download\n"
+                return_when_ready
                 # the helper page displayed depends on validity of persistent override
                 if [ ${LOOPCONFIGOVERRIDE_VALID} == 1 ]; then
                     # change this page to the one (not yet written) for persistent override
-                    sleep 3
                     open https://www.loopandlearn.org/workspace-build-loop
                 else
-                    sleep 3
                     open https://www.loopandlearn.org/workspace-build-loop
                 fi
-                sleep 3
+                sleep 4
                 open "https://loopkit.github.io/loopdocs/build/step14/#prepare-to-build"
                 cd LoopWorkspace
                 sleep 2
@@ -362,9 +375,11 @@ if [ "$WHICH" = "Loop" ]; then
                 exit 0
                 break
                 ;;
+            "Cancel")
+                cancel_entry
+                ;;
             *)
                 invalid_entry
-                break
                 ;;
         esac
     done
@@ -405,7 +420,7 @@ else
     echo -e "\n--------------------------------\n"
     echo -e "${RED}${BOLD}You may need to scroll up in the terminal to see details about options${NC}\n"
     choose_or_cancel
-    options=("Clean Derived Data" "Xcode Cleanup (The Big One)" "Clean Profiles & Derived Data")
+    options=("Clean Derived Data" "Xcode Cleanup (The Big One)" "Clean Profiles & Derived Data" "Cancel")
     select opt in "${options[@]}"
     do
         case $opt in
@@ -436,9 +451,11 @@ else
                 source ./CleanProfCartDerived.sh
                 break
                 ;;
+            "Cancel")
+                cancel_entry
+                ;;
             *)
                 invalid_entry
-                break
                 ;;
         esac
     done

--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -36,18 +36,18 @@ BRANCH_TYPE=master
 while getopts 'dht' OPTION; do
    case "${OPTION}" in
       h) # display Help
-         echo -e "Optional Flags:"
-         echo -e "  -h : print this help message"
-         echo -e "  -t : sets FRESH_CLONE=0"
-         echo -e "  -d : use dev branches (not master)"
+         echo "Optional Flags:"
+         echo "  -h : print this help message"
+         echo "  -t : sets FRESH_CLONE=0"
+         echo "  -d : use dev branches (not master)"
          exit;;
       t) # Do not download a fresh clone - useful for testing
-         echo -e "  -t flag, sets FRESH_CLONE=0"
+         echo "  -t flag, sets FRESH_CLONE=0"
          FRESH_CLONE=0
          sleep 1
          ;;
       d) # set flag to download dev branches
-         echo -e "  -d flag, sets BRANCH_TYPE=dev"
+         echo "  -d flag, sets BRANCH_TYPE=dev"
          BRANCH_TYPE=dev
          LOOP_BUILD="dev"-${LOOP_BUILD}
          sleep 1
@@ -76,23 +76,23 @@ curl -fsSLo ${SCRIPT_DIR}/BuildLoop.sh https://raw.githubusercontent.com/loopnle
 
 # clear
 
-echo -e "${RED}${BOLD}\n\n--------------------------------\n\n"
-echo -e "IMPORTANT\n"
-echo -e "Please understand that this project:\n"
-echo -e "- Is Open Source software"
-echo -e "- Is not \"approved\" for therapy\n"
-echo -e "And that:"
-echo -e "- You take full responsibility for"
-echo -e "  reading and understanding the documenation"
-echo -e "  (LoopsDocs is found at https://loopdocs.org)"
-echo -e "  before building and running this system,"
-echo -e "  and do so at your own risk.\n"
-echo -e "${NC}If you find the font too small to read comfortably"
-echo -e "  Hold down the CMD key and hit + (or -)"
-echo -e "  to increase (decrease) size\n"
-echo -e "${RED}${BOLD}By typing 1 and ENTER, you indicate you agree"
-echo -e "  Any other entry cancels"
-echo -e "\n--------------------------------\n"
+echo "${RED}${BOLD}\n\n--------------------------------\n\n"
+echo "IMPORTANT\n"
+echo "Please understand that this project:\n"
+echo "- Is Open Source software"
+echo "- Is not \"approved\" for therapy\n"
+echo "And that:"
+echo "- You take full responsibility for"
+echo "  reading and understanding the documenation"
+echo "  (LoopsDocs is found at https://loopdocs.org)"
+echo "  before building and running this system,"
+echo "  and do so at your own risk.\n"
+echo "${NC}If you find the font too small to read comfortably"
+echo "  Hold down the CMD key and hit + (or -)"
+echo "  to increase (decrease) size\n"
+echo "${RED}${BOLD}By typing 1 and ENTER, you indicate you agree"
+echo "  Any other entry cancels"
+echo "\n--------------------------------\n"
 options=("Agree")
 select opt in "${options[@]}"
 do
@@ -101,28 +101,28 @@ do
             break
             ;;
         *)
-            echo -e "\n${RED}${BOLD}User did not agree to terms of use.${NC}\n\n";
-            echo -e "You can press the up arrow ⬆️  on the keyboard"
-            echo -e "    and return to repeat script from beginning.\n\n";
+            echo "\n${RED}${BOLD}User did not agree to terms of use.${NC}\n\n";
+            echo "You can press the up arrow ⬆️  on the keyboard"
+            echo "    and return to repeat script from beginning.\n\n";
             exit 0
             break
             ;;
     esac
 done
 
-echo -e "${NC}\n\n\n\n"
+echo "${NC}\n\n\n\n"
 
-echo -e "\n--------------------------------\n"
-echo -e "${BOLD}Welcome to the Loop and Learn\n  Build-Select Script\n${NC}"
-echo -e "This script will assist you in one of these actions:"
-echo -e "  1 Download and build Loop"
-echo -e "      You will be asked to choose from Loop or FreeAPS"
-echo -e "  2 Download and build LoopFollow"
-echo -e "  3 Prepare your computer using a Utility Script"
-echo -e "     when updating your computer or an app"
-echo -e "\n--------------------------------\n"
-echo -e "Type a number from the list below and return to proceed."
-echo -e "${RED}${BOLD}  Any other entry cancels\n${NC}"
+echo "\n--------------------------------\n"
+echo "${BOLD}Welcome to the Loop and Learn\n  Build-Select Script\n${NC}"
+echo "This script will assist you in one of these actions:"
+echo "  1 Download and build Loop"
+echo "      You will be asked to choose from Loop or FreeAPS"
+echo "  2 Download and build LoopFollow"
+echo "  3 Prepare your computer using a Utility Script"
+echo "     when updating your computer or an app"
+echo "\n--------------------------------\n"
+echo "Type a number from the list below and return to proceed."
+echo "${RED}${BOLD}  Any other entry cancels\n${NC}"
 options=("Build Loop" "Build LoopFollow" "Utility Scripts")
 select opt in "${options[@]}"
 do
@@ -140,39 +140,39 @@ do
             break
             ;;
         *)
-            echo -e "\n${RED}${BOLD}User cancelled - selected an invalid option${NC}\n"
-            echo -e "You can press the up arrow ⬆️  on the keyboard"
-            echo -e "    and return to repeat script from beginning.\n\n";
+            echo "\n${RED}${BOLD}User cancelled - selected an invalid option${NC}\n"
+            echo "You can press the up arrow ⬆️  on the keyboard"
+            echo "    and return to repeat script from beginning.\n\n";
             exit 0
             break
             ;;
     esac
 done
 
-echo -e "\n\n\n\n"
+echo "\n\n\n\n"
 
 if [ "$WHICH" = "Loop" ]
 then
-    echo -e "\n--------------------------------\n"
-    echo -e "Before you begin, please ensure that you have Xcode installed,"
-    echo -e "  Xcode command line tools installed, and"
-    echo -e "  your phone is plugged into your computer\n"
-    echo -e "Please select which version of Loop you would like to download and build.\n"
-    echo -e "Type a number from the list below and return"
+    echo "\n--------------------------------\n"
+    echo "Before you begin, please ensure that you have Xcode installed,"
+    echo "  Xcode command line tools installed, and"
+    echo "  your phone is plugged into your computer\n"
+    echo "Please select which version of Loop you would like to download and build.\n"
+    echo "Type a number from the list below and return"
     if [ "$BRANCH_TYPE" = "dev" ]
     then
         BRANCH_LOOP=dev
         BRANCH_FREE=freeaps_dev
         LOOPCONFIGOVERRIDE_VALID=1
-        echo -e "\n ${RED}${BOLD}You are running the script with a -d flag${NC}\n"
-        echo -e " -- If you choose Loop,    branch is ${RED}${BOLD}${BRANCH_LOOP}${NC}"
-        echo -e " -- If you choose FreeAPS, branch is ${RED}${BOLD}${BRANCH_FREE}${NC}\n"
+        echo "\n ${RED}${BOLD}You are running the script with a -d flag${NC}\n"
+        echo " -- If you choose Loop,    branch is ${RED}${BOLD}${BRANCH_LOOP}${NC}"
+        echo " -- If you choose FreeAPS, branch is ${RED}${BOLD}${BRANCH_FREE}${NC}\n"
     else
         BRANCH_LOOP=master
         BRANCH_FREE=freeaps
         LOOPCONFIGOVERRIDE_VALID=0
     fi
-    echo -e "${RED}${BOLD}  Any other entry cancels\n${NC}"
+    echo "${RED}${BOLD}  Any other entry cancels\n${NC}"
     options=("Loop" "FreeAPS")
     select opt in "${options[@]}"
     do
@@ -190,42 +190,39 @@ then
                 break
                 ;;
             *)
-                echo -e "\n${RED}${BOLD}User cancelled - selected an invalid option${NC}\n"
-                echo -e "You can press the up arrow ⬆️  on the keyboard"
-                echo -e "    and return to repeat script from beginning.\n\n";
+                echo "\n${RED}${BOLD}User cancelled - selected an invalid option${NC}\n"
+                echo "You can press the up arrow ⬆️  on the keyboard"
+                echo "    and return to repeat script from beginning.\n\n";
                 exit 0
                 break
                 ;;
         esac
     done
 
-    echo -e "\n\n\n\n"
+    echo "\n\n\n\n"
     LOOP_DIR=~/Downloads/BuildLoop/$FOLDERNAME-$LOOP_BUILD
     if [ ${FRESH_CLONE} == 1 ]
     then
         mkdir $LOOP_DIR
         cd $LOOP_DIR
     fi
-    echo -e "\n\n\n\n"
-    echo -e "\n--------------------------------\n"
+    echo "\n\n\n\n"
+    echo "\n--------------------------------\n"
     if [ ${FRESH_CLONE} == 1 ]
     then
-        echo -e " -- Downloading ${FOLDERNAME} ${BRANCH} to your Downloads folder --"
-        echo -e "      ${LOOP_DIR}\n"
-        echo -e "Issuing this command:"
-        echo -e "    git clone --branch=${BRANCH} --recurse-submodules ${REPO}"
+        echo " -- Downloading ${FOLDERNAME} ${BRANCH} to your Downloads folder --"
+        echo "      ${LOOP_DIR}\n"
+        echo "Issuing this command:"
+        echo "    git clone --branch=${BRANCH} --recurse-submodules ${REPO}"
         git clone --branch=$BRANCH --recurse-submodules $REPO
     fi
-    echo -e "\n--------------------------------\n"
-    echo -e "🛑 Please check for errors in the window above before proceeding."
-    echo -e "   If there are no errors listed, code has successfully downloaded.\n"
-    echo -e "Type 1 and return to continue if and ONLY if"
-    echo -e "  there are no errors (scroll up in terminal window to look for the word error)"
-    echo -e "\nAfter you type 1 and return:"
-    echo -e "* The Loop and Learn webpage with abbreviated build steps will be displayed in your browser"
-    echo -e "* The LoopDocs webpage with detailed build steps will be displayed in your browser"
-    echo -e "* Xcode will open with your current download (wait for it)\n"
-    echo -e "${RED}${BOLD}  Any entry (other than 1) cancels\n${NC}"
+    echo "\n--------------------------------\n"
+    echo "🛑 Please check for errors in the window above before proceeding."
+    echo "   If there are no errors listed, code has successfully downloaded.\n"
+    echo "Type 1 and return to continue if and ONLY if"
+    echo "  there are no errors (scroll up in terminal window to look for the word error)\n"
+    echo "${RED}${BOLD}  Any entry (other than 1) cancels\n${NC}"
+
 
     options=("Continue")
     select opt in "${options[@]}"
@@ -234,95 +231,114 @@ then
             "Continue")
                 if [ ${LOOPCONFIGOVERRIDE_VALID} == 1 ]
                 then
-                    echo -e "\n--------------------------------\n"
-                    # echo -e "Checking status of persistent override file"
+                    echo "\n--------------------------------\n"
+                    # echo "Checking status of persistent override file"
                     # determine if the persistent file exists
                     # if so, remind user
                     if [ -e ../LoopConfigOverride.xcconfig ]
                     then
-                        echo -e "You have a persistent override file:"
-                        echo -e "   ~/Downloads/BuildLoop/LoopConfigOverride.xcconfig"
-                        echo -e "The last 3 lines of that file are shown next:\n"
+                        echo "You have a persistent override file:"
+                        echo "   ~/Downloads/BuildLoop/LoopConfigOverride.xcconfig"
+                        echo "The last 3 lines of that file are shown next:\n"
                         tail -3 ../LoopConfigOverride.xcconfig
-                        echo -e "\n If the last line has your Apple Developer ID"
-                        echo -e "   with no slashes at the beginning of the line"
-                        echo -e "   your targets will be automatically signed"
-                        echo -e "If ID is wrong - you can manually edit the file now\n"
+                        echo "\nIf the last line has your Apple Developer ID"
+                        echo "   with no slashes at the beginning of the line"
+                        echo "   your targets will be automatically signed"
+                        echo "Any line that starts with // is ignored"
+                        echo "If ID is wrong - you can manually edit the file now\n"
                         read -p "Return when ready to continue  " dummy
                     else
                         # make sure the LoopConfigOverride.xcconfig exists in clone
                         if [ -e LoopWorkspace/LoopConfigOverride.xcconfig ]
                         then
-                            echo -e "Choose to enter Apple ID or Sign Manually (later in Xcode)"
+                            echo "Choose to enter Apple ID or wait and Sign Manually (later in Xcode)"
+                            echo "\nIf you choose Apple ID, script will help you find it\n"
                             options=("Enter Apple ID" "Sign Manually")
                             select opt in "${options[@]}"
                             do
                                 case $opt in
                                     "Enter Apple ID")
-                                        echo -e "The Apple Developer page will open"
-                                        echo -e "Log in to the page and note your 10-character Team ID"
-                                        echo -e "Then, return to terminal window"
+                                        echo "The Apple Developer page will open"
+                                        echo "* Log in to the page and note your 10-character Team ID"
+                                        echo " * If the Memebship page does not show, you may need to select it"
+                                        echo " * If you already have your account open in your browser, you may need to go to the already opened page"
+                                        echo " * For reference, this is the page that will open:"
+                                        echo "   https://developer.apple.com/account/#!/membership\n"
+                                        echo "Then, return to terminal window"
                                         open "https://developer.apple.com/account/#!/membership"
                                         read -p "Enter the ID and return: " devID
                                         if [ ${#devID} -ne 10 ]
                                         then
-                                            echo -e "Something was wrong with entry"
-                                            echo -e "You can manually edit the file later or"
-                                            echo -e "  just sign each target in Xcode"
+                                            echo "Something was wrong with entry"
+                                            echo "You can manually edit the file later or"
+                                            echo "  just sign each target in Xcode"
                                         else 
-                                            echo -e "Copying LoopConfigOverride.xcconfig to ~/Downloads/BuildLoop"
-                                            echo -e "Adding a new line with your Apple Developer ID"
+                                            echo "Copying LoopConfigOverride.xcconfig to ~/Downloads/BuildLoop"
+                                            echo "Adding a new line with your Apple Developer ID"
                                             cp -p LoopWorkspace/LoopConfigOverride.xcconfig ..
-                                            echo -e "LOOP_DEVELOPMENT_TEAM = ${devID}" >> ../LoopConfigOverride.xcconfig
+                                            echo "LOOP_DEVELOPMENT_TEAM = ${devID}" >> ../LoopConfigOverride.xcconfig
+                                            echo "You now have a persistent override file:"
+                                            echo "   ~/Downloads/BuildLoop/LoopConfigOverride.xcconfig"
+                                            echo "The last 3 lines of that file are shown next:\n"
                                             tail -3 ../LoopConfigOverride.xcconfig
+                                            echo "\nIf the last line has your Apple Developer ID"
+                                            echo "   with no slashes at the beginning of the line"
+                                            echo "   your targets will be automatically signed"
+                                            echo "Any line that starts with // is ignored"
+                                            echo "If ID is wrong - you can manually edit the file now\n"
+                                            read -p "Return when ready to continue  " dummy
+                                            echo "\nThe next time you build, this permanent file with automatically sign your targets"
                                         fi
                                         break
                                         ;;
                                     "Sign Manually")
                                         break
                                         ;;
+                                      *) # Invalid option
+                                         echo "Error: Invalid option"
+                                         exit;;
                                 esac
                             done
                         else
-                            echo -e "This project does not have a persistent override file"
-                            echo -e "You must sign the targets individually"
+                            echo "This project does not have a persistent override file"
+                            echo "You must sign the targets individually"
                             LOOPCONFIGOVERRIDE_VALID=0
                         fi
                     fi
-                    echo -e "\n--------------------------------\n"
+                    echo "\n--------------------------------\n"
                 fi
                 # the helper page displayed depends on validity of persistent override
                 if [ ${LOOPCONFIGOVERRIDE_VALID} == 1 ]
                 then
                     # change this page to the one (not yet written) for persistent override
-                    echo -e "Opening your browser with abbreviated build instructions"
+                    echo "* The Loop and Learn webpage with abbreviated build steps will be displayed in your browser"
                     sleep 2
                     open https://www.loopandlearn.org/workspace-build-loop
                 else
-                    echo -e "Opening your browser with abbreviated build instructions"
+                    echo "* The Loop and Learn webpage with abbreviated build steps will be displayed in your browser"
                     sleep 2
                     open https://www.loopandlearn.org/workspace-build-loop
                 fi
-                echo -e "Opening your browser with step-by-step build instructions"
+                echo "* The LoopDocs webpage with detailed build steps will be displayed in your browser"
                 sleep 2
                 open "https://loopkit.github.io/loopdocs/build/step14/#prepare-to-build"
                 cd LoopWorkspace
                 sleep 2
-                echo -e "Opening your project in Xcode . . ."
+                echo "* Xcode will open with your current download (wait for it)\n"
                 sleep 2
                 xed .
-                echo -e "\nShell Script Completed successfully\n"
-                echo -e "You may close the terminal window now if you want"
-                echo -e "  or"
-                echo -e "You can press the up arrow ⬆️  on the keyboard"
-                echo -e "    and return to repeat script from beginning.\n\n";
+                echo "\nShell Script Completed\n"
+                echo " * You may close the terminal window now if you want"
+                echo "  or"
+                echo " * You can press the up arrow ⬆️  on the keyboard"
+                echo "    and return to repeat script from beginning.\n\n";
                 exit 0
                 break
                 ;;
             *)
-                echo -e "\n${RED}${BOLD}User cancelled - selected an invalid option${NC}\n"
-                echo -e "You can press the up arrow ⬆️  on the keyboard"
-                echo -e "    and return to repeat script from beginning.\n\n";
+                echo "\n${RED}${BOLD}User cancelled - selected an invalid option${NC}\n"
+                echo "* You can press the up arrow ⬆️  on the keyboard"
+                echo "    and return to repeat script from beginning.\n\n";
                 exit 0
                 break
                 ;;
@@ -333,78 +349,78 @@ elif [ "$WHICH" = "LoopFollow" ]
 then
     # Note that BuildLoopFollow.sh has a warning about Xcode and phone, not needed here
     cd $LOOP_DIR/Scripts
-    echo -e "\n\n--------------------------------\n\n"
-    echo -e "Downloading Loop Follow Script\n"
-    echo -e "\n--------------------------------\n\n"
+    echo "\n\n--------------------------------\n\n"
+    echo "Downloading Loop Follow Script\n"
+    echo "\n--------------------------------\n\n"
     rm ./BuildLoopFollow.sh
     curl -fsSLo ./BuildLoopFollow.sh https://raw.githubusercontent.com/jonfawcett/LoopFollow/Main/BuildLoopFollow.sh
-    echo -e "\n\n\n\n"
+    echo "\n\n\n\n"
     source ./BuildLoopFollow.sh
 else
     cd $LOOP_DIR/Scripts
-    echo -e "\n\n\n\n"
-    echo -e "\n--------------------------------\n"
-    echo -e "${BOLD}These utility scripts automate several cleanup actions${NC}"
-    echo -e "\n--------------------------------\n"
-    echo -e "1 ➡️  Clean Derived Data:\n"
-    echo -e "    This script is used to clean up data from old builds."
-    echo -e "    In other words, it frees up space on your disk."
-    echo -e "    Xcode should be closed when running this script.\n"
-    echo -e "2 ➡️  Xcode Cleanup (The Big One):\n"
-    echo -e "    This script clears even more disk space filled up by using Xcode."
-    echo -e "    It is typically used after uninstalling Xcode"
-    echo -e "      and before installing a new version of Xcode."
-    echo -e "    It can free up a substantial amount of disk space."
-    echo -e "\n    You might be directed to use this script to resolve a problem."
-    echo -e "\n${RED}${BOLD}    Beware that you might be required to fully uninstall"
-    echo -e "      and reinstall Xcode if you run this script with Xcode installed.\n${NC}"
-    echo -e "    Always a good idea to reboot your computer after Xcode Cleanup.\n"
-    echo -e "3 ➡️  Clean Profiles & Derived Data:\n"
-    echo -e "    For those with a paid Apple Developer ID,"
-    echo -e "      this action configures you to have a full year"
-    echo -e "      before you are forced to rebuild your app."
-    echo -e "\n--------------------------------\n"
-    echo -e "Type a number from the list below and return to proceed."
-    echo -e "${RED}${BOLD}  Any other entry - ENTER cancels\n"
-    echo -e "You may need to scroll up in the terminal to see details about options${NC}\n"
+    echo "\n\n\n\n"
+    echo "\n--------------------------------\n"
+    echo "${BOLD}These utility scripts automate several cleanup actions${NC}"
+    echo "\n--------------------------------\n"
+    echo "1 ➡️  Clean Derived Data:\n"
+    echo "    This script is used to clean up data from old builds."
+    echo "    In other words, it frees up space on your disk."
+    echo "    Xcode should be closed when running this script.\n"
+    echo "2 ➡️  Xcode Cleanup (The Big One):\n"
+    echo "    This script clears even more disk space filled up by using Xcode."
+    echo "    It is typically used after uninstalling Xcode"
+    echo "      and before installing a new version of Xcode."
+    echo "    It can free up a substantial amount of disk space."
+    echo "\n    You might be directed to use this script to resolve a problem."
+    echo "\n${RED}${BOLD}    Beware that you might be required to fully uninstall"
+    echo "      and reinstall Xcode if you run this script with Xcode installed.\n${NC}"
+    echo "    Always a good idea to reboot your computer after Xcode Cleanup.\n"
+    echo "3 ➡️  Clean Profiles & Derived Data:\n"
+    echo "    For those with a paid Apple Developer ID,"
+    echo "      this action configures you to have a full year"
+    echo "      before you are forced to rebuild your app."
+    echo "\n--------------------------------\n"
+    echo "Type a number from the list below and return to proceed."
+    echo "${RED}${BOLD}  Any other entry - ENTER cancels\n"
+    echo "You may need to scroll up in the terminal to see details about options${NC}\n"
     options=("Clean Derived Data" "Xcode Cleanup (The Big One)" "Clean Profiles & Derived Data")
     select opt in "${options[@]}"
     do
         case $opt in
             "Clean Derived Data")
-                echo -e "\n--------------------------------\n"
-                echo -e "Downloading Derived Data Script"
-                echo -e "\n--------------------------------\n"
+                echo "\n--------------------------------\n"
+                echo "Downloading Derived Data Script"
+                echo "\n--------------------------------\n"
                 rm ./CleanCartDerived.sh
                 curl -fsSLo ./CleanCartDerived.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/CleanCartDerived.sh
-                echo -e "\n\n\n\n"
+                echo "\n\n\n\n"
                 source ./CleanCartDerived.sh
                 break
                 ;;
             "Xcode Cleanup (The Big One)")
-                echo -e "\n--------------------------------\n"
-                echo -e "Downloading Xcode Cleanup Script"
-                echo -e "\n--------------------------------\n"
+                echo "\n--------------------------------\n"
+                echo "Downloading Xcode Cleanup Script"
+                echo "\n--------------------------------\n"
                 rm ./XcodeClean.sh
                 curl -fsSLo ./XcodeClean.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/XcodeClean.sh
-                echo -e "\n\n\n\n"
+                echo "\n\n\n\n"
                 source ./XcodeClean.sh
                 break
                 ;;
             "Clean Profiles & Derived Data")
-                echo -e "\n--------------------------------\n"
-                echo -e "Downloading Profiles and Derived Data Script"
-                echo -e "\n--------------------------------\n"
+                echo "\n--------------------------------\n"
+                echo "Downloading Profiles and Derived Data Script"
+                echo "\n--------------------------------\n"
                 rm ./CleanProfCartDerived.sh
                 curl -fsSLo ./CleanProfCartDerived.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/CleanProfCartDerived.sh
-                echo -e "\n\n\n\n"
+                echo "\n\n\n\n"
                 source ./CleanProfCartDerived.sh
                 break
                 ;;
             *)
-                echo -e "\n${RED}${BOLD}User cancelled - selected an invalid option${NC}\n"
-                echo -e "You can press the up arrow ⬆️  on the keyboard"
-                echo -e "    and return to repeat script from beginning.\n\n";
+                echo "\n${RED}${BOLD}User cancelled - selected an invalid option${NC}\n"
+                echo "You can press the up arrow ⬆️  on the keyboard"
+                echo "    and return to repeat script from beginning.\n\n";
                 exit 0
                 break
                 ;;


### PR DESCRIPTION
Significant revision of BuildLoop.sh - also known as the Build Select Script.
* use functions to clarify code and improve maintainability
* incorporate flag handling so advanced user can use script to build development branches
* Add flag to indicate whether code base supports use of LoopConfigOverride.xcconfig file for target signing
  * When flag is true, assist user in creating a permanent file used for target signing this time and for all future uses of Build Select
  * Until Loop-dev gets released as Loop 3, the flag stays false for building released code
  * Make Loop and FreeAPS same in terms of released vs development code (drop master from Loop folder names)
* Use full github address for LoopFollow script