### PR TITLE
Modify for embedded spaces

### DIFF
--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -4,22 +4,22 @@
 # this code must be repeated in any build script that uses build_functions.sh
 ############################################################
 
-BUILD_DIR=~/Downloads/BuildLoop
-SCRIPT_DIR=$BUILD_DIR/Scripts
+BUILD_DIR=~/Downloads/"Build Loop"
+SCRIPT_DIR="${BUILD_DIR}/Scripts"
 
-if [ ! -d ${BUILD_DIR} ]; then
-    mkdir $BUILD_DIR
+if [ ! -d "${BUILD_DIR}" ]; then
+    mkdir "${BUILD_DIR}"
 fi
-if [ ! -d ${SCRIPT_DIR} ]; then
-    mkdir $SCRIPT_DIR
+if [ ! -d "${SCRIPT_DIR}" ]; then
+    mkdir "${SCRIPT_DIR}"
 fi
 
 # change directory to $SCRIPT_DIR before curl calls
-cd $SCRIPT_DIR
+cd "${SCRIPT_DIR}"
 
 # define branch (to make it easier when updating)
 # typically branch is main
-SCRIPT_BRANCH=main
+SCRIPT_BRANCH=with-spaces
 
 # store a copy of build_functions.sh in script directory
 curl -fsSLo ./build_functions.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/$SCRIPT_BRANCH/build_functions.sh
@@ -119,10 +119,10 @@ if [ "$WHICH" = "Loop" ]; then
         esac
     done
 
-    LOOP_DIR=$BUILD_DIR"/"$FORK_NAME"-"$DOWNLOAD_DATE
+    LOOP_DIR="${BUILD_DIR}/${FORK_NAME}-${DOWNLOAD_DATE}"
     if [ ${FRESH_CLONE} == 1 ]; then
-        mkdir $LOOP_DIR
-        cd $LOOP_DIR
+        mkdir "${LOOP_DIR}"
+        cd "${LOOP_DIR}"
     fi
     echo -e "\n\n\n\n"
     echo -e "\n--------------------------------\n"

--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -4,7 +4,7 @@
 # this code must be repeated in any build script that uses build_functions.sh
 ############################################################
 
-BUILD_DIR=~/Downloads/"Build Loop"
+BUILD_DIR=~/Downloads/"BuildLoop"
 SCRIPT_DIR="${BUILD_DIR}/Scripts"
 
 if [ ! -d "${BUILD_DIR}" ]; then
@@ -19,7 +19,7 @@ cd "${SCRIPT_DIR}"
 
 # define branch (to make it easier when updating)
 # typically branch is main
-SCRIPT_BRANCH=with-spaces
+SCRIPT_BRANCH=main
 
 # store a copy of build_functions.sh in script directory
 curl -fsSLo ./build_functions.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/$SCRIPT_BRANCH/build_functions.sh

--- a/BuildLoopFixedDev.sh
+++ b/BuildLoopFixedDev.sh
@@ -4,7 +4,7 @@
 # this code must be repeated in any build script that uses build_functions.sh
 ############################################################
 
-BUILD_DIR=~/Downloads/"Build Loop"
+BUILD_DIR=~/Downloads/"BuildLoop"
 SCRIPT_DIR="${BUILD_DIR}/Scripts"
 
 if [ ! -d "${BUILD_DIR}" ]; then
@@ -19,7 +19,7 @@ cd "${SCRIPT_DIR}"
 
 # define branch (to make it easier when updating)
 # typically branch is main
-SCRIPT_BRANCH=with-spaces
+SCRIPT_BRANCH=main
 
 # store a copy of build_functions.sh in script directory
 curl -fsSLo ./build_functions.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/$SCRIPT_BRANCH/build_functions.sh

--- a/BuildLoopFixedDev.sh
+++ b/BuildLoopFixedDev.sh
@@ -4,22 +4,22 @@
 # this code must be repeated in any build script that uses build_functions.sh
 ############################################################
 
-BUILD_DIR=~/Downloads/BuildLoop
-SCRIPT_DIR=$BUILD_DIR/Scripts
+BUILD_DIR=~/Downloads/"Build Loop"
+SCRIPT_DIR="${BUILD_DIR}/Scripts"
 
-if [ ! -d ${BUILD_DIR} ]; then
-    mkdir $BUILD_DIR
+if [ ! -d "${BUILD_DIR}" ]; then
+    mkdir "${BUILD_DIR}"
 fi
-if [ ! -d ${SCRIPT_DIR} ]; then
-    mkdir $SCRIPT_DIR
+if [ ! -d "${SCRIPT_DIR}" ]; then
+    mkdir "${SCRIPT_DIR}"
 fi
 
 # change directory to $SCRIPT_DIR before curl calls
-cd $SCRIPT_DIR
+cd "${SCRIPT_DIR}"
 
 # define branch (to make it easier when updating)
 # typically branch is main
-SCRIPT_BRANCH=main
+SCRIPT_BRANCH=with-spaces
 
 # store a copy of build_functions.sh in script directory
 curl -fsSLo ./build_functions.sh https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/$SCRIPT_BRANCH/build_functions.sh
@@ -102,10 +102,10 @@ do
     esac
 done
 
-LOOP_DIR=$BUILD_DIR"/"$FORK_NAME"-"$BRANCH"-"$DOWNLOAD_DATE"_"$FIXED_SHA
+LOOP_DIR="${BUILD_DIR}/${FORK_NAME}-${BRANCH}-${DOWNLOAD_DATE}_${FIXED_SHA}"
 if [ ${FRESH_CLONE} == 1 ]; then
-    mkdir $LOOP_DIR
-    cd $LOOP_DIR
+    mkdir "${LOOP_DIR}"
+    cd "${LOOP_DIR}"
 fi
 echo -e "\n\n\n\n"
 echo -e "\n--------------------------------\n"
@@ -128,7 +128,7 @@ do
     case $opt in
         "Continue")
             cd LoopWorkspace
-            this_dir=$(pwd)
+            this_dir="$(pwd)"
             echo -e "In ${this_dir}"
             if [ ${FRESH_CLONE} == 0 ]; then
                 echo -e "\nScript used with test flag, extra steps to prepare downloaded code\n"

--- a/build_functions.sh
+++ b/build_functions.sh
@@ -26,7 +26,7 @@ FRESH_CLONE=1
 # Prepare date-time stamp for folder
 DOWNLOAD_DATE=$(date +'%y%m%d-%H%M')
 
-BUILD_DIR=~/Downloads/"Build Loop"
+BUILD_DIR=~/Downloads/"BuildLoop"
 SCRIPT_DIR="${BUILD_DIR}/Scripts"
 
 OVERRIDE_FILE=LoopConfigOverride.xcconfig
@@ -119,7 +119,7 @@ function return_when_ready() {
 
 function report_persistent_config_override() {
     echo -e "The file used by Xcode to sign your app is found at:"
-    echo -e "   ~/Downloads/Build Loop/${OVERRIDE_FILE}"
+    echo -e "   ~/Downloads/BuildLoop/${OVERRIDE_FILE}"
     echo -e "The last 3 lines of that file are shown next:\n"
     tail -3 "${OVERRIDE_FULLPATH}"
     echo -e "\nIf the last line has your Apple Developer ID"
@@ -129,7 +129,7 @@ function report_persistent_config_override() {
     echo -e "  If ID is OK, hit return"
     echo -e "  If ID is not OK:"
     echo -e "    Edit the file before hitting return"
-    echo -e "     step 1: open finder, navigate to Downloads/Build Loop"
+    echo -e "     step 1: open finder, navigate to Downloads/BuildLoop"
     echo -e "     step 2: double click on "${OVERRIDE_FILE}""
     echo -e "     step 3: edit and save file"
     return_when_ready
@@ -154,7 +154,7 @@ function create_persistent_config_override() {
         echo -e "Something was wrong with entry"
         echo -e "You can manually sign each target in Xcode"
     else 
-        echo -e "Creating ~/Downloads/Build Loop/${OVERRIDE_FILE}"
+        echo -e "Creating ~/Downloads/BuildLoop/${OVERRIDE_FILE}"
         echo -e "   with your Apple Developer ID\n"
         cp -p "${OVERRIDE_FILE}" "${OVERRIDE_FULLPATH}"
         echo -e "LOOP_DEVELOPMENT_TEAM = ${devID}" >> "${OVERRIDE_FULLPATH}"

--- a/build_functions.sh
+++ b/build_functions.sh
@@ -26,11 +26,11 @@ FRESH_CLONE=1
 # Prepare date-time stamp for folder
 DOWNLOAD_DATE=$(date +'%y%m%d-%H%M')
 
-BUILD_DIR=~/Downloads/BuildLoop
-SCRIPT_DIR=$BUILD_DIR/Scripts
+BUILD_DIR=~/Downloads/"Build Loop"
+SCRIPT_DIR="${BUILD_DIR}/Scripts"
 
 OVERRIDE_FILE=LoopConfigOverride.xcconfig
-OVERRIDE_FULLPATH=$BUILD_DIR"/"$OVERRIDE_FILE
+OVERRIDE_FULLPATH="${BUILD_DIR}/${OVERRIDE_FILE}"
 
 function usage() {
     echo -e "Allowed arguments:"
@@ -119,9 +119,9 @@ function return_when_ready() {
 
 function report_persistent_config_override() {
     echo -e "The file used by Xcode to sign your app is found at:"
-    echo -e "   ~/Downloads/BuildLoop/${OVERRIDE_FILE}"
+    echo -e "   ~/Downloads/Build Loop/${OVERRIDE_FILE}"
     echo -e "The last 3 lines of that file are shown next:\n"
-    tail -3 $OVERRIDE_FULLPATH
+    tail -3 "${OVERRIDE_FULLPATH}"
     echo -e "\nIf the last line has your Apple Developer ID"
     echo -e "   with no slashes at the beginning of the line"
     echo -e "   your targets will be automatically signed"
@@ -129,8 +129,8 @@ function report_persistent_config_override() {
     echo -e "  If ID is OK, hit return"
     echo -e "  If ID is not OK:"
     echo -e "    Edit the file before hitting return"
-    echo -e "     step 1: open finder, navigate to Downloads/BuildLoop"
-    echo -e "     step 2: double click on LoopConfigOverride.xcconfig"
+    echo -e "     step 1: open finder, navigate to Downloads/Build Loop"
+    echo -e "     step 2: double click on "${OVERRIDE_FILE}""
     echo -e "     step 3: edit and save file"
     return_when_ready
 }
@@ -154,10 +154,10 @@ function create_persistent_config_override() {
         echo -e "Something was wrong with entry"
         echo -e "You can manually sign each target in Xcode"
     else 
-        echo -e "Creating ~/Downloads/BuildLoop/LoopConfigOverride.xcconfig"
+        echo -e "Creating ~/Downloads/Build Loop/${OVERRIDE_FILE}"
         echo -e "   with your Apple Developer ID\n"
-        cp -p LoopConfigOverride.xcconfig $OVERRIDE_FULLPATH
-        echo -e "LOOP_DEVELOPMENT_TEAM = ${devID}" >> $OVERRIDE_FULLPATH
+        cp -p "${OVERRIDE_FILE}" "${OVERRIDE_FULLPATH}"
+        echo -e "LOOP_DEVELOPMENT_TEAM = ${devID}" >> "${OVERRIDE_FULLPATH}"
         report_persistent_config_override
         echo -e "\nXcode uses the permanent file to automatically sign your targets"
     fi
@@ -165,11 +165,11 @@ function create_persistent_config_override() {
 
 function check_config_override_existence_offer_to_configure() {
     echo -e "\n--------------------------------\n"
-    if [ -e $OVERRIDE_FULLPATH ]; then
+    if [ -e "${OVERRIDE_FULLPATH}" ]; then
         report_persistent_config_override
     else
-        # make sure the LoopConfigOverride.xcconfig exists in clone
-        if [ -e $OVERRIDE_FILE ]; then
+        # make sure the "${OVERRIDE_FILE}" exists in clone
+        if [ -e "${OVERRIDE_FILE}" ]; then
             echo -e "Choose to enter Apple Developer ID or wait and Sign Manually (later in Xcode)"
             echo -e "\nIf you choose Apple Developer ID, script will help you find it"
             choose_or_cancel


### PR DESCRIPTION
Turns out the embedded spaces are a problem for bash or zsh. 
Ignore the comments about "with zsh" in the commit messages.
A number of variables were created for directories when preparing for when Loop-dev will be released.
All of those need to be protected with quotes and curly braces to keep working if there are spaces embedded in the users's home directory.

First test using the with-spaces branch.
Then create a without-spaces branch for creating a PR to main.
* put quotes and curly braces around variables
  * this allows scripts to work if ~/Downloads has an embedded space