### PR TITLE
new version of target_dir

### DIFF
--- a/CustomizationSelect.sh
+++ b/CustomizationSelect.sh
@@ -158,7 +158,8 @@ echo "Loop Prepared Customizations Selection"
 cd "$STARTING_DIR"
 
 if [ "$(basename "$PWD")" != "LoopWorkspace" ]; then
-    target_dir="$(find /Users/$USER/Downloads/BuildLoop -type d -name LoopWorkspace -exec sh -c 'case "$(basename "$(dirname "$1")")" in Loop[-_]lnl[-_]patches-*|Loop-*) echo "$1" ;; esac' _ {} \; | sort -rn | head -n 1)"
+    target_dir=$(find /Users/$USER/Downloads/BuildLoop -maxdepth 1 -type d -name "Loop*" -exec [ -d "{}"/LoopWorkspace ] \; -print 2>/dev/null | xargs -I {} stat -f "%m %N" {} | sort -rn | head -n 1 | awk '{print $2"/LoopWorkspace"}')
+
     if [ -z "$target_dir" ]; then
         echo "Error: No folder containing LoopWorkspace found in ~/Downloads/BuildLoop."
     else


### PR DESCRIPTION
Update so script finds the most recent LoopWorkspace that is in the correct depth with respect to ~/Downloads/BuildLoop.

Tested prior to merge:
* tested with LoopWorkspace down "too many" levels
* tested with LoopWorkspace at top level of BuildLoop
* tested with terminal a LoopWorkspace folder