### PR TITLE
Fix git submodule requirement to build iAPS >=v8.0.0

### DIFF
--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -204,7 +204,7 @@ function erase_previous_line {
 : ${USE_OVERRIDE_IN_REPO:="0"}
 
 # Default: some projects use submodules (and need --recurse-submodule)
-# Some, like iAPS and LoopFollow, do not use submodules
+# Some, like LoopFollow, do not use submodules
 #    in that case, set CLONE_SUB_MODULES to 0 in the src/Build script
 : ${CLONE_SUB_MODULES:="1"}
 

--- a/BuildLoopCaregiver.sh
+++ b/BuildLoopCaregiver.sh
@@ -201,7 +201,7 @@ function erase_previous_line {
 : ${USE_OVERRIDE_IN_REPO:="0"}
 
 # Default: some projects use submodules (and need --recurse-submodule)
-# Some, like iAPS and LoopFollow, do not use submodules
+# Some, like LoopFollow, do not use submodules
 #    in that case, set CLONE_SUB_MODULES to 0 in the src/Build script
 : ${CLONE_SUB_MODULES:="1"}
 

--- a/BuildLoopFollow.sh
+++ b/BuildLoopFollow.sh
@@ -202,7 +202,7 @@ function erase_previous_line {
 : ${USE_OVERRIDE_IN_REPO:="0"}
 
 # Default: some projects use submodules (and need --recurse-submodule)
-# Some, like iAPS and LoopFollow, do not use submodules
+# Some, like LoopFollow, do not use submodules
 #    in that case, set CLONE_SUB_MODULES to 0 in the src/Build script
 : ${CLONE_SUB_MODULES:="1"}
 

--- a/BuildTrio.sh
+++ b/BuildTrio.sh
@@ -212,7 +212,7 @@ function erase_previous_line {
 : ${USE_OVERRIDE_IN_REPO:="0"}
 
 # Default: some projects use submodules (and need --recurse-submodule)
-# Some, like iAPS and LoopFollow, do not use submodules
+# Some, like LoopFollow, do not use submodules
 #    in that case, set CLONE_SUB_MODULES to 0 in the src/Build script
 : ${CLONE_SUB_MODULES:="1"}
 

--- a/Build_iAPS.sh
+++ b/Build_iAPS.sh
@@ -16,8 +16,8 @@ USE_OVERRIDE_IN_REPO="1"
 OVERRIDE_FILE="ConfigOverride.xcconfig"
 DEV_TEAM_SETTING_NAME="DEVELOPER_TEAM"
 
-# sub modules are not required
-CLONE_SUB_MODULES="0"
+# sub modules are required
+CLONE_SUB_MODULES="1"
 
 FLAG_USE_SHA=0  # Initialize FLAG_USE_SHA to 0
 FIXED_SHA=""    # Initialize FIXED_SHA with an empty string
@@ -209,7 +209,7 @@ function erase_previous_line {
 : ${USE_OVERRIDE_IN_REPO:="0"}
 
 # Default: some projects use submodules (and need --recurse-submodule)
-# Some, like iAPS and LoopFollow, do not use submodules
+# Some, like LoopFollow, do not use submodules
 #    in that case, set CLONE_SUB_MODULES to 0 in the src/Build script
 : ${CLONE_SUB_MODULES:="1"}
 

--- a/BuildxDrip4iOS.sh
+++ b/BuildxDrip4iOS.sh
@@ -209,7 +209,7 @@ function erase_previous_line {
 : ${USE_OVERRIDE_IN_REPO:="0"}
 
 # Default: some projects use submodules (and need --recurse-submodule)
-# Some, like iAPS and LoopFollow, do not use submodules
+# Some, like LoopFollow, do not use submodules
 #    in that case, set CLONE_SUB_MODULES to 0 in the src/Build script
 : ${CLONE_SUB_MODULES:="1"}
 

--- a/inline_functions/build_functions.sh
+++ b/inline_functions/build_functions.sh
@@ -27,7 +27,7 @@
 : ${USE_OVERRIDE_IN_REPO:="0"}
 
 # Default: some projects use submodules (and need --recurse-submodule)
-# Some, like iAPS and LoopFollow, do not use submodules
+# Some, like LoopFollow, do not use submodules
 #    in that case, set CLONE_SUB_MODULES to 0 in the src/Build script
 : ${CLONE_SUB_MODULES:="1"}
 

--- a/src/Build_iAPS.sh
+++ b/src/Build_iAPS.sh
@@ -11,8 +11,8 @@ USE_OVERRIDE_IN_REPO="1"
 OVERRIDE_FILE="ConfigOverride.xcconfig"
 DEV_TEAM_SETTING_NAME="DEVELOPER_TEAM"
 
-# sub modules are not required
-CLONE_SUB_MODULES="0"
+# sub modules are required
+CLONE_SUB_MODULES="1"
 
 FLAG_USE_SHA=0  # Initialize FLAG_USE_SHA to 0
 FIXED_SHA=""    # Initialize FIXED_SHA with an empty string


### PR DESCRIPTION
# Problem
iAPS refactored its codebase to utilize git submodules starting with [release v8.0.0](https://github.com/Artificial-Pancreas/iAPS/releases/tag/v8.0.0). Running the iAPS build script (`Build_iAPS.sh`) after this release leaves users with a partial checkout without submodules and unable to build.

# Solution
This PR fixes the `Build_iAPS.sh` by reflecting the git submodule requirement in the `Build_iAPS.sh` script.